### PR TITLE
chore: remove unnecessary pull_request_target event from GitHub Actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,7 +21,6 @@ name: CI
 on:
   push:
   pull_request:
-  pull_request_target:
 
 # cancel in-progress runs for the same branch or PR
 concurrency:


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration by removing the `pull_request_target` trigger from the `.github/workflows/github-actions.yml` file.

## Summary by Sourcery

CI:
- Remove pull_request_target trigger from the CI workflow configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to streamline event triggers and improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->