### PR TITLE
fix(filter): use shallow copy of factory config for filters violating interface to avoid pointer sharing

### DIFF
--- a/pkg/filter/accesslog/access_log.go
+++ b/pkg/filter/accesslog/access_log.go
@@ -76,8 +76,10 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 
 // PrepareFilterChain prepare chain when http context init
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer.
+	cpConf := *factory.conf
 	f := &Filter{
-		conf: factory.conf,
+		conf: &cpConf,
 		alw:  factory.alw,
 	}
 	chain.AppendDecodeFilters(f)

--- a/pkg/filter/header/header.go
+++ b/pkg/filter/header/header.go
@@ -56,7 +56,7 @@ func (p *Plugin) Kind() string {
 }
 
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{}, nil
+	return &FilterFactory{cfg: &Config{}}, nil
 }
 
 func (factory *FilterFactory) Config() any {
@@ -68,7 +68,9 @@ func (factory *FilterFactory) Apply() error {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/host/host.go
+++ b/pkg/filter/host/host.go
@@ -55,11 +55,13 @@ func (p *Plugin) Kind() string {
 }
 
 func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
-	return &FilterFactory{}, nil
+	return &FilterFactory{cfg: &Config{}}, nil
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/http/loadbalancer/loadbalancer.go
+++ b/pkg/filter/http/loadbalancer/loadbalancer.go
@@ -69,7 +69,9 @@ func (factory *FilterFactory) Apply() error {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/llm/tokenizer/tokenizer.go
+++ b/pkg/filter/llm/tokenizer/tokenizer.go
@@ -134,7 +134,9 @@ func (factory *FilterFactory) Config() any { return factory.cfg }
 func (factory *FilterFactory) Apply() error { return registerLLMMetrics() }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy}
 	chain.AppendDecodeFilters(f)
 	chain.AppendEncodeFilters(f)
 	return nil

--- a/pkg/filter/opa/opa.go
+++ b/pkg/filter/opa/opa.go
@@ -99,7 +99,9 @@ func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain fi
 		return fmt.Errorf("failed to prepare OPA query: %w", err)
 	}
 
-	f := &Filter{cfg: factory.cfg, preparedQuery: &preparedQuery}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer.
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy, preparedQuery: &preparedQuery}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/prometheus/metric.go
+++ b/pkg/filter/prometheus/metric.go
@@ -76,8 +76,10 @@ func (factory *FilterFactory) Apply() error {
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contextHttp.HttpContext, chain filter.FilterChain) error {
 
+	// Shallow copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	cpConfig := *factory.Cfg
 	f := &Filter{
-		Cfg:  factory.Cfg,
+		Cfg:  &cpConfig,
 		Prom: factory.Prom,
 	}
 	f.Prom.SetPushGatewayUrl(f.Cfg.Rules.PushGatewayURL, f.Cfg.Rules.MetricPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Fixes shallow copy issue in several filters where factory.cfg pointers were directly passed to Filter instances. 
Now each Filter receives an independent copy of its factory config, ensuring safety during hot reload.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #795

**Special notes for your reviewer**:

- Only applies shallow copy to filters with simple value-type configs.
- Does not affect filters requiring deep copy.
- Includes added comments explaining the shallow copy usage and hot reload safety.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note
Shallow copy applied to selected filters to avoid pointer sharing of factory configuration during hot reload.
```

## Summary by Sourcery

Create an independent shallow copy of factory.cfg in PrepareFilterChain of selected filters (event, header, host, loadbalancer, tokenizer, and OPA) to prevent shared pointers and fix hot reload issues

Bug Fixes:
- Avoid pointer sharing of factory configuration by creating a shallow copy for each filter instance to ensure hot reload safety

Documentation:
- Add comments in filter code explaining the shallow copy usage for hot reload safety

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Filters now receive isolated copies of their configuration instead of sharing a factory-held configuration, reducing risk of cross-component mutation and improving stability and predictability.
  * No public APIs or exported type signatures were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->