### PR TITLE
fix(filter): deep copy factory config for filters with complex configs to avoid pointer sharing

### DIFF
--- a/pkg/filter/auth/jwt/jwt.go
+++ b/pkg/filter/auth/jwt/jwt.go
@@ -82,7 +82,8 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg, errMsg: factory.errMsg, providerJwks: factory.providerJwks}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{cfg: factory.cfg.DeepCopy(), errMsg: factory.errMsg, providerJwks: factory.providerJwks}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -224,4 +225,67 @@ func checkToken(value, prefix, providerName string, provider Provider) bool {
 
 func (factory *FilterFactory) Config() any {
 	return factory.cfg
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+	cpConfig := *config
+
+	if config.Rules != nil {
+		cpConfig.Rules = make([]Rules, 0, len(config.Rules))
+		for _, rules := range config.Rules {
+			cpRules := *rules.DeepCopy()
+			cpConfig.Rules = append(cpConfig.Rules, cpRules)
+		}
+	}
+
+	if config.Providers != nil {
+		cpConfig.Providers = make([]Providers, 0, len(config.Providers))
+		for _, providers := range config.Providers {
+			cpProviders := *providers.DeepCopy()
+			cpConfig.Providers = append(cpConfig.Providers, cpProviders)
+		}
+	}
+
+	return &cpConfig
+}
+
+func (rules *Rules) DeepCopy() *Rules {
+	if rules == nil {
+		return nil
+	}
+	cpRules := *rules
+	cpRules.Requires = *rules.Requires.DeepCopy()
+	return &cpRules
+}
+
+func (providers *Providers) DeepCopy() *Providers {
+	if providers == nil {
+		return nil
+	}
+	cpProviders := *providers
+
+	if providers.Local != nil {
+		cpLocal := *providers.Local
+		cpProviders.Local = &cpLocal
+	}
+	if providers.Remote != nil {
+		cpRemote := *providers.Remote
+		cpProviders.Remote = &cpRemote
+	}
+	return &cpProviders
+}
+
+func (requires *Requires) DeepCopy() *Requires {
+	if requires == nil {
+		return nil
+	}
+	cpRequires := *requires
+	cpRequires.RequiresAll = make([]Requirement, len(requires.RequiresAll))
+	copy(cpRequires.RequiresAll, requires.RequiresAll)
+	return &cpRequires
 }

--- a/pkg/filter/authority/authority.go
+++ b/pkg/filter/authority/authority.go
@@ -61,7 +61,8 @@ func (factory *FilterFactory) Apply() error {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{cfg: factory.cfg.DeepCopy()}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/authority/config.go
+++ b/pkg/filter/authority/config.go
@@ -73,3 +73,43 @@ type (
 	// LimitType the authority rule limit enum
 	LimitType int32
 )
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (rule *AuthorityRule) DeepCopy() *AuthorityRule {
+	if rule == nil {
+		return nil
+	}
+
+	cp := *rule
+
+	if rule.Items != nil {
+		cp.Items = make([]string, len(rule.Items))
+		copy(cp.Items, rule.Items)
+	} else {
+		cp.Items = nil
+	}
+
+	return &cp
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (ac *AuthorityConfiguration) DeepCopy() *AuthorityConfiguration {
+	if ac == nil {
+		return nil
+	}
+
+	cp := *ac
+
+	if ac.Rules != nil {
+		cp.Rules = make([]AuthorityRule, len(ac.Rules))
+		for i := range ac.Rules {
+			cp.Rules[i] = *ac.Rules[i].DeepCopy()
+		}
+	} else {
+		cp.Rules = nil
+	}
+
+	return &cp
+}

--- a/pkg/filter/cors/cors.go
+++ b/pkg/filter/cors/cors.go
@@ -73,7 +73,8 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{cfg: factory.cfg.DeepCopy()}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -131,4 +132,23 @@ func (factory *FilterFactory) Apply() error {
 
 func (factory *FilterFactory) Config() any {
 	return factory.cfg
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+
+	cp := *config
+
+	if config.AllowOrigin != nil {
+		cp.AllowOrigin = make([]string, len(config.AllowOrigin))
+		copy(cp.AllowOrigin, config.AllowOrigin)
+	} else {
+		cp.AllowOrigin = nil
+	}
+
+	return &cp
 }

--- a/pkg/filter/csrf/csrf.go
+++ b/pkg/filter/csrf/csrf.go
@@ -74,7 +74,8 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{cfg: factory.cfg.DeepCopy()}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -136,4 +137,23 @@ func (factory *FilterFactory) Apply() error {
 
 func (factory *FilterFactory) Config() any {
 	return factory.cfg
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+
+	cp := *config
+
+	if config.IgnoreMethods != nil {
+		cp.IgnoreMethods = make([]string, len(config.IgnoreMethods))
+		copy(cp.IgnoreMethods, config.IgnoreMethods)
+	} else {
+		cp.IgnoreMethods = nil
+	}
+
+	return &cp
 }

--- a/pkg/filter/event/event.go
+++ b/pkg/filter/event/event.go
@@ -63,7 +63,9 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg}
+	// Make a shallow copy of the factory config to avoid sharing the factory's pointer
+	cfgCopy := *factory.cfg
+	f := &Filter{cfg: &cfgCopy}
 	chain.AppendDecodeFilters(f)
 	return nil
 }

--- a/pkg/filter/failinject/filter.go
+++ b/pkg/filter/failinject/filter.go
@@ -57,8 +57,9 @@ func (factory *FilterFactory) Config() any {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contextHttp.HttpContext, chain filter.FilterChain) error {
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
 	f := Filter{
-		cfg: factory.cfg,
+		cfg: factory.cfg.DeepCopy(),
 	}
 	chain.AppendDecodeFilters(f)
 	return nil
@@ -150,4 +151,30 @@ func percentage(odds int) bool {
 	// generate rand number in 1-100
 	num := rand.Intn(100) + 1 // NOSONAR
 	return num <= odds
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+
+	cp := &Config{}
+
+	if config.Rules != nil {
+		cp.Rules = make(map[URI]*Rule, len(config.Rules))
+		for k, r := range config.Rules {
+			if r == nil {
+				cp.Rules[k] = nil
+			} else {
+				rr := *r
+				cp.Rules[k] = &rr
+			}
+		}
+	} else {
+		cp.Rules = nil
+	}
+
+	return cp
 }

--- a/pkg/filter/http/grpcproxy/grpc.go
+++ b/pkg/filter/http/grpcproxy/grpc.go
@@ -152,7 +152,8 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{cfg: factory.cfg, descriptor: factory.descriptor, pools: factory.pools, extReg: factory.extReg, registered: factory.registered}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{cfg: factory.cfg.DeepCopy(), descriptor: factory.descriptor, pools: factory.pools, extReg: factory.extReg, registered: factory.registered}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -430,4 +431,35 @@ func configCheck(cfg *Config) error {
 		return perrors.Errorf("grpc descriptor source config `descriptor_source_strategy` is `%s`, maybe set it `%s`", cfg.DescriptorSourceStrategy.String(), AUTO)
 	}
 	return nil
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+
+	cp := *config
+
+	if config.Rules != nil {
+		cp.Rules = make([]*Rule, len(config.Rules))
+		for i, r := range config.Rules {
+			if r == nil {
+				cp.Rules[i] = nil
+				continue
+			}
+			nr := &Rule{
+				Selector: r.Selector,
+				Match: Match{
+					Method: r.Match.Method,
+				},
+			}
+			cp.Rules[i] = nr
+		}
+	} else {
+		cp.Rules = nil
+	}
+
+	return &cp
 }

--- a/pkg/filter/mcp/mcpserver/filter.go
+++ b/pkg/filter/mcp/mcpserver/filter.go
@@ -108,8 +108,9 @@ func (f *FilterFactory) PrepareFilterChain(_ *contexthttp.HttpContext, chain fil
 	sseHandler := transport.NewSSEHandler(sessionManager)
 	contentNegotiator := transport.NewContentNegotiator()
 
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
 	mcpFilter := &MCPServerFilter{
-		cfg:               f.cfg,
+		cfg:               f.cfg.DeepCopy(),
 		registry:          f.registry,
 		errorHandler:      NewErrorHandler(),
 		responseBuilder:   NewResponseBuilder(),

--- a/pkg/filter/sentinel/circuitbreaker/circuit_breaker.go
+++ b/pkg/filter/sentinel/circuitbreaker/circuit_breaker.go
@@ -77,8 +77,9 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 	return &FilterFactory{cfg: &Config{}}, nil
 }
 
+// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
 func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	chain.AppendDecodeFilters(&Filter{cfg: factory.cfg, matcher: factory.matcher})
+	chain.AppendDecodeFilters(&Filter{cfg: factory.cfg.DeepCopy(), matcher: factory.matcher})
 	return nil
 }
 
@@ -164,4 +165,34 @@ func loadRules(rules []*circuitbreaker.Rule) error {
 		return err
 	}
 	return nil
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+	cpConfig := *config
+
+	if config.Resources != nil {
+		cpConfig.Resources = make([]*pkgs.Resource, len(config.Resources))
+		for index, resource := range config.Resources {
+			if resource != nil {
+				cpConfig.Resources[index] = resource.DeepCopy()
+			}
+		}
+	}
+
+	if config.Rules != nil {
+		cpConfig.Rules = make([]*circuitbreaker.Rule, len(config.Rules))
+		for index, rule := range config.Rules {
+			if rule != nil {
+				cpRule := *rule
+				cpConfig.Rules[index] = &cpRule
+			}
+		}
+	}
+
+	return &cpConfig
 }

--- a/pkg/filter/sentinel/config.go
+++ b/pkg/filter/sentinel/config.go
@@ -40,3 +40,22 @@ type (
 	// MatchStrategy API match strategy
 	MatchStrategy int32
 )
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (resource *Resource) DeepCopy() *Resource {
+	if resource == nil {
+		return nil
+	}
+	cpResource := *resource
+	if resource.Items != nil {
+		cpResource.Items = make([]*Item, len(resource.Items))
+		for index, orig := range resource.Items {
+			if orig != nil {
+				cp := *orig
+				cpResource.Items[index] = &cp
+			}
+		}
+	}
+	return &cpResource
+}

--- a/pkg/filter/sentinel/ratelimit/rate_limit.go
+++ b/pkg/filter/sentinel/ratelimit/rate_limit.go
@@ -68,7 +68,8 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 }
 
 func (factory *FilterFactory) PrepareFilterChain(ctx *contexthttp.HttpContext, chain filter.FilterChain) error {
-	f := &Filter{conf: factory.conf, matcher: factory.matcher}
+	// Deep copy config to avoid pointer sharing (factory.cfg may change at runtime)
+	f := &Filter{conf: factory.conf.DeepCopy(), matcher: factory.matcher}
 	chain.AppendDecodeFilters(f)
 	return nil
 }
@@ -130,4 +131,33 @@ func OnRulesUpdate(rules []*Rule) {
 	if _, err := flow.LoadRules(enableRules); err != nil {
 		logger.Warnf("rate limit load rules err: %v", err)
 	}
+}
+
+// DeepCopy returns a new independent copy of Config
+// // Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *Config) DeepCopy() *Config {
+	if config == nil {
+		return nil
+	}
+	cpConfig := *config
+	if config.Resources != nil {
+		cpConfig.Resources = make([]*pkgs.Resource, len(config.Resources))
+		for index, resource := range config.Resources {
+			if resource != nil {
+				cpConfig.Resources[index] = resource.DeepCopy()
+			}
+		}
+	}
+
+	if config.Rules != nil {
+		cpConfig.Rules = make([]*Rule, len(config.Rules))
+		for index, rule := range config.Rules {
+			if rule != nil {
+				cpRule := *rule
+				cpConfig.Rules[index] = &cpRule
+			}
+		}
+	}
+
+	return &cpConfig
 }

--- a/pkg/model/mcpserver.go
+++ b/pkg/model/mcpserver.go
@@ -222,3 +222,187 @@ func GetPathParameterNames(pathTemplate string) []string {
 
 	return names
 }
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *McpServerConfig) DeepCopy() *McpServerConfig {
+	if config == nil {
+		return nil
+	}
+
+	cpConfig := *config
+
+	// Deep copy Tools
+	if config.Tools != nil {
+		cpConfig.Tools = make([]ToolConfig, len(config.Tools))
+		for i := range config.Tools {
+			cpConfig.Tools[i] = *config.Tools[i].DeepCopy()
+		}
+	}
+
+	// Deep copy Resources
+	if config.Resources != nil {
+		cpConfig.Resources = make([]ResourceConfig, len(config.Resources))
+		copy(cpConfig.Resources, config.Resources)
+	}
+
+	// Deep copy ResourceTemplates
+	if config.ResourceTemplates != nil {
+		cpConfig.ResourceTemplates = make([]ResourceTemplateConfig, len(config.ResourceTemplates))
+		for i := range config.ResourceTemplates {
+			cpConfig.ResourceTemplates[i] = *config.ResourceTemplates[i].DeepCopy()
+		}
+	}
+
+	// Deep copy Prompts
+	if config.Prompts != nil {
+		cpConfig.Prompts = make([]PromptConfig, len(config.Prompts))
+		for i := range config.Prompts {
+			cpConfig.Prompts[i] = *config.Prompts[i].DeepCopy()
+		}
+	}
+
+	return &cpConfig
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (toolConfig *ToolConfig) DeepCopy() *ToolConfig {
+	if toolConfig == nil {
+		return nil
+	}
+	cpConfig := *toolConfig
+	cpConfig.Request = *toolConfig.Request.DeepCopy()
+
+	if toolConfig.Args != nil {
+		cpConfig.Args = make([]ArgConfig, len(toolConfig.Args))
+		for index := range toolConfig.Args {
+			argPtr := &toolConfig.Args[index]
+			cpConfig.Args[index] = *argPtr.DeepCopy()
+		}
+	}
+
+	return &cpConfig
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *RequestConfig) DeepCopy() *RequestConfig {
+	if config == nil {
+		return nil
+	}
+	cpConfig := *config
+	if config.Headers != nil {
+		cpConfig.Headers = make(map[string]string, len(config.Headers))
+		for k, v := range config.Headers {
+			cpConfig.Headers[k] = v
+		}
+	}
+
+	return &cpConfig
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *ArgConfig) DeepCopy() *ArgConfig {
+	if config == nil {
+		return nil
+	}
+	cpConfig := *config
+	if config.Enum != nil {
+		cpConfig.Enum = make([]string, len(config.Enum))
+		copy(cpConfig.Enum, config.Enum)
+	}
+	return &cpConfig
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (param *ResourceTemplateParameter) DeepCopy() *ResourceTemplateParameter {
+	if param == nil {
+		return nil
+	}
+
+	cpParam := *param
+
+	if param.Enum != nil {
+		cpParam.Enum = make([]string, len(param.Enum))
+		copy(cpParam.Enum, param.Enum)
+	}
+
+	return &cpParam
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (ann *ResourceTemplateAnnotations) DeepCopy() *ResourceTemplateAnnotations {
+	if ann == nil {
+		return nil
+	}
+
+	cpAnn := *ann
+
+	// Deep copy Audience slice
+	if ann.Audience != nil {
+		cpAnn.Audience = make([]string, len(ann.Audience))
+		copy(cpAnn.Audience, ann.Audience)
+	}
+
+	// Deep copy Priority pointer
+	if ann.Priority != nil {
+		p := *ann.Priority
+		cpAnn.Priority = &p
+	}
+
+	return &cpAnn
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *ResourceTemplateConfig) DeepCopy() *ResourceTemplateConfig {
+	if config == nil {
+		return nil
+	}
+
+	cpConfig := *config
+
+	// Deep copy Parameters slice
+	if config.Parameters != nil {
+		cpConfig.Parameters = make([]ResourceTemplateParameter, len(config.Parameters))
+		for i := range config.Parameters {
+			paramPtr := &config.Parameters[i]
+			cpConfig.Parameters[i] = *paramPtr.DeepCopy()
+		}
+	}
+
+	// Deep copy Annotations pointer
+	if config.Annotations != nil {
+		cpConfig.Annotations = config.Annotations.DeepCopy()
+	}
+
+	return &cpConfig
+}
+
+// DeepCopy returns a new independent copy of Config
+// Deep copy slices/maps to avoid sharing pointers with the factory
+func (config *PromptConfig) DeepCopy() *PromptConfig {
+	if config == nil {
+		return nil
+	}
+
+	cp := *config
+
+	// Deep copy Arguments slice
+	if config.Arguments != nil {
+		cp.Arguments = make([]PromptArgumentConfig, len(config.Arguments))
+		copy(cp.Arguments, config.Arguments)
+	}
+
+	// Deep copy Messages slice
+	if config.Messages != nil {
+		cp.Messages = make([]PromptMessageConfig, len(config.Messages))
+		copy(cp.Messages, config.Messages)
+	}
+
+	return &cp
+}


### PR DESCRIPTION
Some Pixiu filters have complex configurations (maps, slices, nested structs). Passing the factory.cfg pointer directly can cause in-flight requests to read inconsistent or modified configs when FilterManager.ReLoad() updates factory instances at runtime, violating the HttpFilterFactory interface contract.

This commit implements DeepCopy() for complex filter configs and updates PrepareFilterChain to use it. Each filter instance now has its own independent config, preventing runtime inconsistencies.

Affected files:
- pkg/filter/auth/jwt/jwt.go
- pkg/filter/authority/authority.go
- pkg/filter/authority/config.go
- pkg/filter/cors/cors.go
- pkg/filter/csrf/csrf.go
- pkg/filter/event/event.go
- pkg/filter/failinject/filter.go
- pkg/filter/http/grpcproxy/grpc.go
- pkg/filter/mcp/mcpserver/filter.go
- pkg/filter/sentinel/circuitbreaker/circuit_breaker.go
- pkg/filter/sentinel/config.go
- pkg/filter/sentinel/ratelimit/rate_limit.go
- pkg/model/mcpserver.go

**What this PR does**:

- Implements `DeepCopy()` for complex filter configurations.
- Updates `PrepareFilterChain` in affected filters to use `DeepCopy()` instead of directly passing `factory.cfg`.
- Ensures each filter instance has an independent copy of its configuration, preventing runtime inconsistencies during hot reload.
- Adds comments explaining deep copy usage and runtime safety.

**Which issue(s) this PR fixes**:
Fixes #795

**Special notes for your reviewer**:

- Only applies deep copy to filters with complex configs (maps, slices, nested structs).
- Does not affect filters where shallow copy is sufficient.
- Reviewers should verify that all `DeepCopy()` implementations correctly handle nested structures.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented shared mutable configuration between factories and filters by using independent configuration copies, reducing runtime config mutation issues.

* **Refactor**
  * Added comprehensive deep-copy support across filter and model configurations so each filter instance receives an isolated config, improving stability and data safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->