### PR TITLE
feat: add Pixiu skills

### DIFF
--- a/skills/pixiu-filter-author/SKILL.md
+++ b/skills/pixiu-filter-author/SKILL.md
@@ -96,8 +96,11 @@ Do not write code until the user has answered, in plain words:
    upstream), or both?
 2. **Kind**: the string that identifies the filter in yaml. It MUST start
    with `dgp.filter.http.` for HTTP filters or
-   `dgp.filter.networkfilter.` for L4. Suggest a name; confirm the user
-   is happy.
+   match Pixiu's current Network filter constants for L4 filters, usually
+   `dgp.filter.network.`. The built-in HTTP connection manager is the
+   special network-filter Kind `dgp.filter.httpconnectionmanager`.
+   Suggest a name after checking `pkg/common/constant/key.go`; confirm
+   the user is happy.
 3. **Config fields**: what yaml keys does the user want? (`allow_origin`,
    `max_request_bytes`, etc.)
 4. **Where to put the package**: the convention is
@@ -157,7 +160,7 @@ func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus { return filt
 func (f *Filter) Encode(ctx *http.HttpContext) filter.FilterStatus { return filter.Continue }
 ```
 
-Two subtle rules the interface alone does not enforce:
+A few subtle rules the interface alone does not enforce:
 
 - **Do not reuse `factory.cfg` directly in the Filter instance.** The
   factory's config pointer can be hot-reloaded at runtime. Copy the
@@ -291,9 +294,11 @@ For full-workflow answers, emit a compact delivery checklist:
 
 ### Always
 
-- Name the `Kind` constant with the correct prefix — `dgp.filter.http.`
-  or `dgp.filter.networkfilter.`. Put it in a `const` at the top of the
-  package.
+- Name the `Kind` constant with the correct prefix. HTTP filters use
+  `dgp.filter.http.*`; Network filters must match the current constants
+  in `pkg/common/constant/key.go` such as `dgp.filter.network.*` or the
+  special `dgp.filter.httpconnectionmanager`. Put it in a `const` at
+  the top of the package.
 - Use the project's logger: `import ".../pkg/logger"` and
   `logger.Infof(...)`. Never `fmt.Println`, never stdlib `log`.
 - Deep-copy config into the per-request `Filter` instance — the factory
@@ -309,6 +314,8 @@ For full-workflow answers, emit a compact delivery checklist:
 
 ### Never
 
+- Expose internal error details in HTTP responses. Return generic
+  client-facing errors and log full diagnostics server-side only.
 - Skip the blank import. This is the #1 filter bug. If something does
   not seem to register, re-check this before anything else.
 - Mutate `ctx.TargetResp` from a Decode filter. Use Encode.

--- a/skills/pixiu-filter-author/SKILL.md
+++ b/skills/pixiu-filter-author/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: pixiu-filter-author
+description: |
+  Create a new HTTP or Network filter for Apache dubbo-go-pixiu. Use whenever
+  the user wants to add a custom filter, extend gateway per-request behavior,
+  implement a new auth/logging/transformation/proxy filter, or mentions
+  "pixiu filter", "dgp.filter", "http_filters", "filter chain", "custom filter",
+  "extend pixiu", or is porting a filter from Envoy/Kong/APISIX to pixiu.
+  Strongly prefer this skill over ad-hoc generation even when the user does
+  not say the word "skill" — getting the SPI registration right is the single
+  biggest source of "my filter does not run" bug reports.
+allowed-tools: [Read, Grep, Glob, Edit, Write, Bash]
+metadata:
+  version: "0.1.2"
+  domain: extension
+  scope: implementation
+  triggers: ["filter", "pixiu filter", "dgp.filter", "http_filters", "filter chain", "custom filter", "extend pixiu"]
+  pixiu_min_version: "0.6.0"
+  role: specialist
+---
+
+# pixiu-filter-author — Authoring HTTP / Network Filters
+
+dubbo-go-pixiu's extension surface is Envoy-style: every filter is a Go
+package that registers a `Plugin` in `init()`, and a central file
+(`pkg/pluginregistry/registry.go`) blank-imports all such packages to
+activate them. A single missing blank import is the most common reason a
+newly written filter "does nothing" — so this skill treats registration as
+a first-class concern, not an afterthought.
+
+## When to Use
+
+Use this skill when the user wants to:
+- Add a new HTTP filter (auth, logging, header rewriting, rate limiting,
+  request transformation, metric emission, etc.).
+- Add a new Network (L4) filter (e.g. a custom connection manager).
+- Port a filter from Envoy / Kong / APISIX onto pixiu.
+- Fix an existing filter that "isn't running" — start at Step 5 (blank
+  import) and Step 3 (phase).
+
+**Do NOT use this skill for:**
+- Editing the yaml that *uses* an existing filter → that is plain config
+  work. Only include a minimal mounting snippet when you create a new
+  filter in this skill.
+- Mounting an already-registered filter such as CORS, JWT, OPA, MCP,
+  LLM proxy, or Dubbo proxy. In that case do not scaffold code and do
+  not touch `pkg/pluginregistry/registry.go`; answer with the smallest
+  `http_filters` snippet and state that the filter already exists.
+- Adding a registry adapter (Nacos, ZK, Consul), a new protocol
+  listener (WebSocket, MQTT), or a custom load-balancing algorithm —
+  these are different SPI hubs and out of scope for this skill. Point
+  the user to the relevant interface file
+  (`pkg/common/extension/adapter/adapter.go`,
+  `pkg/listener/listener.go`, or
+  `pkg/cluster/loadbalancer/`) and let them work directly.
+
+## Prerequisites
+
+- pixiu ≥ 0.6.0. Verify with `grep dubbo-go-pixiu go.mod` in Step 0.
+- The user should be inside a clone of `github.com/apache/dubbo-go-pixiu`
+  (or a fork). If they are not, stop and ask — this skill edits repo files.
+
+## Steps
+
+### Step 0 — Verify Context (ALWAYS FIRST, no exceptions)
+
+Before writing a single line of code, read the current shape of three
+files. pixiu's SPI is stable but not frozen, and your instinct about
+these interfaces can be one minor version stale:
+
+1. `pkg/common/extension/filter/filter.go` — the four interfaces
+   (`HttpFilterPlugin`, `HttpFilterFactory`, `HttpDecodeFilter`,
+   `HttpEncodeFilter`), plus `NetworkFilterPlugin` / `NetworkFilter` for
+   L4. Read signatures, especially `PrepareFilterChain`.
+2. `pkg/pluginregistry/registry.go` — the blank-import list you will
+   extend in Step 5. Note the alphabetical order within groups.
+3. `pkg/filter/cors/cors.go` — the shortest idiomatic HTTP filter in the
+   tree. A single file, all four types (`Plugin`, `FilterFactory`,
+   `Filter`, `Config`) declared together. Note: `cors` ships **without**
+   a `_test.go` — that matches roughly half of the existing filter
+   packages. See Step 7 for the project's actual convention.
+
+Then `ls pkg/filter/` and `ls pkg/filter/http/` to see the existing
+directory conventions. Do not assume — layouts evolve (e.g. `cors` lives
+at `pkg/filter/cors/`, while proxy filters live at
+`pkg/filter/http/httpproxy/`, `pkg/filter/http/dubboproxy/`).
+
+Load `references/filter-interface.md` if you need a side-by-side of the
+four interfaces with their pixiu source-line anchors.
+
+### Step 1 — Clarify the Filter Shape (STOP and ask)
+
+Do not write code until the user has answered, in plain words:
+
+1. **Phase**: Decode (request, before upstream), Encode (response, after
+   upstream), or both?
+2. **Kind**: the string that identifies the filter in yaml. It MUST start
+   with `dgp.filter.http.` for HTTP filters or
+   `dgp.filter.networkfilter.` for L4. Suggest a name; confirm the user
+   is happy.
+3. **Config fields**: what yaml keys does the user want? (`allow_origin`,
+   `max_request_bytes`, etc.)
+4. **Where to put the package**: the convention is
+   `pkg/filter/<name>/` for ordinary filters and
+   `pkg/filter/http/<name>/` for *proxy-style* filters (the ones that
+   actually call upstream). If unsure, ask — getting this right once
+   beats moving files later.
+
+If the user says "just write something reasonable", pick a minimal
+request-logging filter as the placeholder and be explicit about the
+assumptions in a short summary before coding.
+
+### Step 2 — Scaffold the Package
+
+Create the directory and initial files. Two shapes are idiomatic in the
+existing tree:
+
+- **Single file** (cors, csrf, jwt, header, host, tracing): everything
+  lives in `<name>.go`. This is the dominant pattern for non-proxy
+  filters — about 20 of the existing filter packages follow it.
+- **Split files** (network/dubboproxy, mcp/mcpserver, ai/kvcache, etc.):
+  `plugin.go`, `filter.go`, `config.go`. Use this only when the package
+  has more than ~200 LOC or several distinct types worth separating.
+
+Test files (`*_test.go`) are **not** part of either default shape —
+they are added on a per-filter basis when the logic warrants it. See
+Step 7.
+
+Optionally run `bash scripts/scaffold-filter.sh <name>` from this skill
+— it emits a single-file skeleton (no test file by default, matching
+the common case). Do NOT treat the scaffolder output as final; the
+user still owns every Config field.
+
+### Step 3 — Implement the Four Interfaces
+
+The four types for an HTTP filter, in order:
+
+```go
+type Plugin struct{}
+func (p *Plugin) Kind() string { return Kind }
+func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
+    return &FilterFactory{cfg: &Config{}}, nil
+}
+
+type FilterFactory struct{ cfg *Config }
+func (f *FilterFactory) Config() any { return f.cfg }
+func (f *FilterFactory) Apply() error { /* validate / defaults */ return nil }
+func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
+    inst := &Filter{cfg: f.cfg.DeepCopy()} // or a shallow copy of the pieces you need
+    chain.AppendDecodeFilters(inst)        // or AppendEncodeFilters, or both
+    return nil
+}
+
+type Filter struct{ cfg *Config }
+func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus { return filter.Continue }
+// and/or:
+func (f *Filter) Encode(ctx *http.HttpContext) filter.FilterStatus { return filter.Continue }
+```
+
+Two subtle rules the interface alone does not enforce:
+
+- **Do not reuse `factory.cfg` directly in the Filter instance.** The
+  factory's config pointer can be hot-reloaded at runtime. Copy the
+  fields you need into the Filter when `PrepareFilterChain` runs. The
+  CORS filter's `factory.cfg.DeepCopy()` pattern is the canonical
+  reference.
+- **Decode vs Encode is about the phase, not the direction.**  Mutating
+  `ctx.TargetResp` (the outbound body) from a Decode filter is a
+  category error — read `references/context-api.md` before touching
+  response state.
+- **Response-body mutation is an Encode-only checklist.** For redaction,
+  watermarking, compression, or similar response transforms, load
+  `references/context-api.md` and `references/testing-patterns.md`.
+  Operate on `ctx.TargetResp` only after confirming the concrete
+  response type. Handle `*client.UnaryResponse` deliberately, pass
+  streaming responses through unless the user explicitly asked for
+  streaming support, gate by `Content-Type` when the behavior is textual,
+  and write table-driven tests for empty body, unsupported content type,
+  configured/default values, and invalid config.
+
+For Network filters, the interface surface is larger
+(`ServeHTTP`, `OnData`, `OnTripleData`, etc.); reuse an existing one
+(`pkg/filter/network/httpconnectionmanager/`) as a template.
+
+### Step 4 — Register in `init()`
+
+```go
+func init() {
+    filter.RegisterHttpFilter(&Plugin{})
+}
+```
+
+For Network filters the call is `filter.RegisterNetworkFilterPlugin(&Plugin{})`.
+
+### Step 5 — Add the Blank Import (THIS is where filters die silently)
+
+Edit `pkg/pluginregistry/registry.go` and insert, in alphabetical order
+within the correct grouping:
+
+```go
+_ "github.com/apache/dubbo-go-pixiu/pkg/filter/<name>"
+```
+
+(Or `.../pkg/filter/http/<name>` if the package lives there.)
+
+If this line is missing, the filter compiles fine, `go test` passes, and
+pixiu boots — but the filter never registers, and yaml using its Kind
+fails with `no filter found for name ...`. This is *the* pixiu rite of
+passage.
+
+You can run `bash scripts/gen-registry-import.sh` to auto-scan
+`pkg/filter/` and `pkg/filter/http/` for packages that contain
+`filter.RegisterHttpFilter` but are not yet blank-imported. The script
+prints a diff; review it, then apply.
+
+If the user asked for a "full workflow", do not stop after writing the
+filter package. The final answer must include either the applied
+`registry.go` edit or a precise patch hunk the user can apply.
+
+### Step 6 — Wire Up Config
+
+Add your filter to `configs/conf.yaml` (or whatever bootstrap the user
+is running), under the `http_filters` list of the
+`dgp.filter.httpconnectionmanager` network filter. Order matters: CORS /
+request auth / tracing normally run before proxy-style filters, while
+response-shaping filters must be placed where their Encode phase will
+see the intended response.
+
+```yaml
+- name: dgp.filter.http.<name>
+  config:
+    <field>: <value>
+```
+
+Do NOT put the filter under `static_resources.listeners[].filter_chains[].filters[]`
+directly — that's the Network filter level. HTTP filters always live
+inside `dgp.filter.httpconnectionmanager`'s `http_filters`.
+
+### Step 7 — Tests (optional; follow the project's actual convention)
+
+Pixiu does **not** have a "every filter must have tests" policy. As of
+0.6, of the ~38 packages under `pkg/filter/`:
+
+- **Roughly 20 ship without `_test.go`** — including cors, csrf, jwt,
+  httpproxy, dubboproxy, grpcproxy, tracing, traffic, failinject,
+  network/dubboproxy, network/httpconnectionmanager, llm/proxy.
+- **Roughly 18 do have tests** — including accesslog, opa, prometheus,
+  metric, sentinel/ratelimit, sentinel/circuitbreaker, ai/kvcache,
+  authority, header, host, http/proxyrewrite, mcp/mcpserver, auth/saml,
+  auth/mcp.
+
+The split is by **whether the filter has logic worth testing**, not by
+policy. Reasonable defaults to mirror existing style:
+
+- **Skip the test** when your filter is a thin config-driven header
+  rewriter, an auth check that delegates to a library, a one-line proxy
+  switch, or otherwise mostly setup — matches cors / csrf / jwt /
+  httpproxy.
+- **Add a table-driven test** when your filter has branching logic,
+  state transitions, or response-body transformation — matches
+  sentinel/ratelimit / opa / accesslog.
+
+If you choose to test, see `references/testing-patterns.md` for a
+skeleton aligned with how existing tests in the repo are written. If
+you choose not to test, do not generate an empty stub `*_test.go` —
+empty test files are noise and do not match repo style.
+
+When in doubt, ask the user. Either answer is consistent with the
+project; pick deliberately.
+
+### Step 8 — Verify End-to-End
+
+- `go build ./...` from repo root must succeed.
+- If you wrote tests: `go test ./pkg/filter/<name>/...` must pass.
+- If the user has the gateway binary, `./dubbo-go-pixiu gateway start -c
+  configs/conf.yaml` should log the filter's Kind among the registered
+  filters at boot.
+- A `curl` against the listener port should exhibit the new behavior.
+
+For full-workflow answers, emit a compact delivery checklist:
+
+- Filter package path and the `Kind` string.
+- `pkg/pluginregistry/registry.go` blank-import patch or applied edit.
+- Minimal `http_filters` yaml snippet mounting the new filter.
+- Test decision: either real test files and commands, or a short reason
+  why no `_test.go` is consistent with nearby pixiu filters.
+- Verification commands run or, if not runnable, the exact commands the
+  user should run.
+
+## Cross-Cutting Rules
+
+### Always
+
+- Name the `Kind` constant with the correct prefix — `dgp.filter.http.`
+  or `dgp.filter.networkfilter.`. Put it in a `const` at the top of the
+  package.
+- Use the project's logger: `import ".../pkg/logger"` and
+  `logger.Infof(...)`. Never `fmt.Println`, never stdlib `log`.
+- Deep-copy config into the per-request `Filter` instance — the factory
+  config is live and can change under you.
+- Keep imports in three alphabetically ordered groups (stdlib, third
+  party, internal) — this is a project-wide convention and the CI
+  linter enforces it.
+- Match the surrounding package style on testing: look at neighbors of
+  comparable complexity (cors / jwt for simple, opa / sentinel for
+  branching) and follow their pattern.
+- In full-workflow mode, always produce registry and config artifacts.
+  A filter package alone is incomplete even when it compiles.
+
+### Never
+
+- Skip the blank import. This is the #1 filter bug. If something does
+  not seem to register, re-check this before anything else.
+- Mutate `ctx.TargetResp` from a Decode filter. Use Encode.
+- Rewrite response streams unless the user explicitly requested
+  streaming support and you have designed backpressure/lifetime handling.
+- Launch a goroutine inside Decode/Encode without a parent context and
+  timeout — it will outlive the request.
+- Return `nil, error` from `CreateFilterFactory` for a non-fatal config
+  problem — instead return a zero-valued factory and log a warning; this
+  keeps pixiu bootable.
+- Generate an empty stub `*_test.go` "to be filled in later". Either
+  write a real test or omit the file.
+
+## Common Pitfalls
+
+1. **"My filter doesn't run" = missing blank import.** 90% of the time.
+   Check `pkg/pluginregistry/registry.go` first.
+2. **Phase confusion.** Auth → Decode; response shaping → Encode.
+   Filters are invoked Decode forward, Encode reversed — draw it out
+   once and the rest follows.
+3. **`ctx.Abort` vs `ctx.Next`.** `Abort` stops subsequent Decode
+   filters, but Encode filters of already-entered filters still run.
+4. **Per-request state in the factory.** The factory is shared across
+   all requests on a listener; per-request state belongs in the Filter
+   struct created by `PrepareFilterChain`.
+5. **Dubbo-aware filters running too early.** Anything that needs the
+   request's Dubbo parameters parsed must run *after*
+   `dgp.filter.httpconnectionmanager` has done its work — effectively,
+   it must be inside its `http_filters` list.
+6. **Yaml tags omitted on Config struct.** Without
+   `yaml:"field_name" mapstructure:"field_name"`, your field will not
+   bind. Follow CORS's tag pattern exactly.
+
+## References
+
+| File | When to load |
+|---|---|
+| [references/filter-interface.md](references/filter-interface.md) | Step 2–3: implementing `Plugin`/`FilterFactory`/`Filter` |
+| [references/context-api.md](references/context-api.md) | Step 3 or any debugging of request/response state (`SourceResp` vs `TargetResp`, params, headers) |
+| [references/testing-patterns.md](references/testing-patterns.md) | Step 7 ONLY IF you are writing tests; the project does not require them on every filter |
+| [references/pluginregistry-howto.md](references/pluginregistry-howto.md) | Step 5 if you need alphabetical-order or grouping details, or to understand what `gen-registry-import.sh` does |
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/scaffold-filter.sh <name> [--proxy]` | Creates `pkg/filter/<name>/<name>.go` (or `pkg/filter/http/<name>/` with split files if `--proxy`) containing a minimal scaffold with the four types, `Kind`, and `init()`. Does **not** create a `_test.go` — add one only if the filter's logic warrants it (Step 7). |
+| `scripts/gen-registry-import.sh` | Scans `pkg/filter/` and `pkg/filter/http/` for packages registering an HTTP or Network filter, computes the symmetric difference against the blank-import list in `pkg/pluginregistry/registry.go`, and prints the additions needed. Safe: it never writes. |

--- a/skills/pixiu-filter-author/references/context-api.md
+++ b/skills/pixiu-filter-author/references/context-api.md
@@ -19,13 +19,13 @@ chain position.
 | `ctx.Params` | `map[string]any` | route params + filter-decoded values (JWT claims, etc.) |
 | `ctx.SourceResp` | upstream's response (raw) | what the client/adapter returned; available in Encode |
 | `ctx.TargetResp` | what pixiu will ship to client | what the client will see; Encode may mutate |
-| `ctx.Err` | `error` | set by upstream failures; Encode can decide to mask or expose |
+| `ctx.SendLocalReply(status, body)` | local reply state + `TargetResp` | emit a generic local error response and stop proxying; log internal details server-side only |
+| `ctx.GetStatusCode()` / `ctx.GetLocalReplyBody()` / `ctx.LocalReply()` | local reply state | inspect whether a filter already sent a local response |
 | `ctx.Route` | `*model.RouteAction` | matched route, cluster name, timeouts |
 | `ctx.API` | `*router.API` | api-config route, only populated when the api filter is in play |
 | `ctx.Next()` | — | explicitly advance; rarely needed — returning `filter.Continue` is the idiomatic way |
 | `ctx.Abort()` | — | stop subsequent Decode filters; Encode still runs for filters already on-chain |
 | `ctx.AddFinishCallbacks(f)` | — | run `f` after response is sent; use for cleanup / metric emission |
-| `ctx.WriteErr(...)`, `ctx.WriteWithStatus(...)` | — | respond from within the filter (bypass upstream) |
 
 ## `SourceResp` vs `TargetResp` — the number-one Encode bug
 
@@ -65,7 +65,7 @@ checking.
 
 ## Lifecycle in one diagram
 
-```
+```text
 client → ctx = new HttpContext
        → Decode[0] → Decode[1] → ... → Decode[N]
                                          ↓

--- a/skills/pixiu-filter-author/references/context-api.md
+++ b/skills/pixiu-filter-author/references/context-api.md
@@ -1,0 +1,81 @@
+# `HttpContext` — Field Cheat Sheet
+
+Source: `pkg/context/http/context.go`. Read that file when this reference
+looks out of date; the struct evolves.
+
+`HttpContext` is the per-request object your filter receives in both
+`Decode` and `Encode`. It threads the original request, the upstream
+response, the routed-client response, params, headers, and the filter
+chain position.
+
+## The fields filters actually use
+
+| Field / method | Lives in | Typical use |
+|---|---|---|
+| `ctx.Request` | inbound `*http.Request` | read headers, method, path, raw body |
+| `ctx.Writer` | `http.ResponseWriter` | write headers or body **before** handing control to the router; usually for Decode that terminates early (CORS preflight, rate-limit 429) |
+| `ctx.GetHeader(name)` | — | case-insensitive header read on the inbound request |
+| `ctx.AddHeader(k, v)` / `ctx.RemoveHeader(k)` | — | mutate the request headers forwarded upstream |
+| `ctx.Params` | `map[string]any` | route params + filter-decoded values (JWT claims, etc.) |
+| `ctx.SourceResp` | upstream's response (raw) | what the client/adapter returned; available in Encode |
+| `ctx.TargetResp` | what pixiu will ship to client | what the client will see; Encode may mutate |
+| `ctx.Err` | `error` | set by upstream failures; Encode can decide to mask or expose |
+| `ctx.Route` | `*model.RouteAction` | matched route, cluster name, timeouts |
+| `ctx.API` | `*router.API` | api-config route, only populated when the api filter is in play |
+| `ctx.Next()` | — | explicitly advance; rarely needed — returning `filter.Continue` is the idiomatic way |
+| `ctx.Abort()` | — | stop subsequent Decode filters; Encode still runs for filters already on-chain |
+| `ctx.AddFinishCallbacks(f)` | — | run `f` after response is sent; use for cleanup / metric emission |
+| `ctx.WriteErr(...)`, `ctx.WriteWithStatus(...)` | — | respond from within the filter (bypass upstream) |
+
+## `SourceResp` vs `TargetResp` — the number-one Encode bug
+
+- **`SourceResp`** is the raw response from the upstream (HTTP backend,
+  Dubbo generic invoke result, gRPC message). Treat as read-only
+  input.
+- **`TargetResp`** is what pixiu will serialize and send to the client.
+  This is the mutable one for an Encode filter.
+
+A very common mistake is to mutate `SourceResp` in Encode and expect
+the client to see the change. It does not. The chain may have already
+copied data into `TargetResp`. Always check which field the filter you
+are writing should touch.
+
+## Headers: inbound vs outbound
+
+- Inbound headers (what the client sent): `ctx.Request.Header` and the
+  `ctx.GetHeader` shortcut.
+- Outbound headers to the upstream: modify `ctx.Request.Header` in
+  Decode — proxies forward the same object.
+- Response headers to the client: `ctx.Writer.Header()`.
+
+Do not assume the three maps share keys.
+
+## Params — the cross-filter scratch pad
+
+`ctx.Params` (a `map[string]any`) is how filters pass information to
+each other. Examples:
+
+- JWT filter stores claims under `"user"`.
+- Rate-limit filter reads `"user"` to pick a quota bucket.
+- OPA filter reads `"user"` to build its input document.
+
+If you invent a new key, document it in `references/` of whichever
+skill publishes it. Do not rely on keys from other teams without
+checking.
+
+## Lifecycle in one diagram
+
+```
+client → ctx = new HttpContext
+       → Decode[0] → Decode[1] → ... → Decode[N]
+                                         ↓
+                                       upstream (Dubbo / HTTP / gRPC)
+                                         ↓
+       ← Encode[0] ← Encode[1] ← ... ← Encode[N]   (reverse order)
+       ← write response  ← finish callbacks
+```
+
+Every Decode filter that returns `Continue` implicitly opts into having
+its Encode half run. Conversely, if `ctx.Abort()` is called at Decode[i],
+Encode[j] for j < i still runs (because those filters already entered
+the chain), but j > i does not.

--- a/skills/pixiu-filter-author/references/filter-interface.md
+++ b/skills/pixiu-filter-author/references/filter-interface.md
@@ -1,0 +1,144 @@
+# The Four (Plus Two) HTTP Filter Interfaces
+
+Source of truth: `pkg/common/extension/filter/filter.go`. Read that file
+first; this reference exists to annotate the shape and the "why".
+
+## Interfaces, in implementation order
+
+### 1. `HttpFilterPlugin`
+
+```go
+type HttpFilterPlugin interface {
+    Kind() string                                   // unique identifier, e.g. "dgp.filter.http.cors"
+    CreateFilterFactory() (HttpFilterFactory, error)
+}
+```
+
+Every package has exactly one `Plugin` struct that implements this. It
+is what gets registered in `init()` via `filter.RegisterHttpFilter`.
+`Kind()` returns a package-level `const Kind = "..."` — define it once
+at the top of the file and reuse everywhere.
+
+### 2. `HttpFilterFactory`
+
+```go
+type HttpFilterFactory interface {
+    Config() any
+    Apply() error
+    PrepareFilterChain(ctx *http.HttpContext, chain FilterChain) error
+}
+```
+
+Factories are **listener-scoped singletons** (one per listener into
+which the filter is wired). `Config()` returns a pointer so that
+pixiu's config manager can deserialize yaml into it. `Apply()` runs
+**after** deserialization — this is where you validate fields and set
+defaults. `PrepareFilterChain` is called **per request**: construct a
+fresh `Filter` instance, append it to the chain.
+
+Two correctness rules that bit many contributors:
+
+- `Config()` must return a **pointer**, not the struct by value. Yaml
+  binding silently no-ops on a non-pointer.
+- Do not share `factory.cfg` pointer with the per-request `Filter`.
+  Copy out the fields you need so a hot-reload of the factory config
+  does not race with in-flight requests.
+
+### 3. `HttpDecodeFilter`
+
+```go
+type HttpDecodeFilter interface {
+    Decode(ctx *http.HttpContext) FilterStatus
+}
+```
+
+Invoked in **declaration order** as the request travels inbound. Return
+`filter.Continue` to move on or `filter.Stop` to short-circuit. Common
+decode work: authentication, rate limiting, path rewriting, enriching
+`ctx.Params`, emitting request-size metrics.
+
+### 4. `HttpEncodeFilter`
+
+```go
+type HttpEncodeFilter interface {
+    Encode(ctx *http.HttpContext) FilterStatus
+}
+```
+
+Invoked in **reverse declaration order** on the response path. Common
+encode work: response header rewriting, body transformation, masking
+PII, emitting response-size metrics.
+
+A single filter package may implement either, neither (rare), or both.
+If both, `PrepareFilterChain` calls both `chain.AppendDecodeFilters`
+and `chain.AppendEncodeFilters`.
+
+### 5. `NetworkFilterPlugin` (L4)
+
+```go
+type NetworkFilterPlugin interface {
+    Kind() string
+    CreateFilter(config any) (NetworkFilter, error)
+    Config() any
+}
+```
+
+Network filters sit one layer down — they own the raw connection and
+dispatch per-protocol. `dgp.filter.httpconnectionmanager` is a network
+filter; its `http_filters` list is where HTTP filters above attach.
+Unless you are adding a wholly new L4 behavior, you do not need to
+write a Network filter.
+
+### 6. `NetworkFilter`
+
+Large surface: `ServeHTTP`, `OnDecode`, `OnEncode`, `OnData`,
+`OnTripleData`, `OnUnaryRPC`, `OnStreamRPC`, `Close`. Reuse an existing
+implementation as a template; see
+`pkg/filter/network/httpconnectionmanager/` and
+`pkg/filter/network/grpcconnectionmanager/`.
+
+## Reference filter walkthrough — CORS
+
+`pkg/filter/cors/cors.go` is the shortest idiomatic HTTP filter. ~150
+lines, single file, Decode-only. Pattern to copy:
+
+```go
+const Kind = constant.HTTPCorsFilter // "dgp.filter.http.cors"
+
+func init() { filter.RegisterHttpFilter(&Plugin{}) }
+
+type (
+    Plugin        struct{}
+    FilterFactory struct{ cfg *Config }
+    Filter        struct{ cfg *Config }
+    Config        struct { /* yaml-tagged fields */ }
+)
+
+func (p *Plugin) Kind() string                                   { return Kind }
+func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) { return &FilterFactory{cfg: &Config{}}, nil }
+
+func (f *FilterFactory) Config() any { return f.cfg }
+func (f *FilterFactory) Apply() error { return nil }
+func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
+    inst := &Filter{cfg: f.cfg.DeepCopy()}
+    chain.AppendDecodeFilters(inst)
+    return nil
+}
+
+func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus { ... }
+```
+
+Add `Encode` and `chain.AppendEncodeFilters(inst)` when you need both
+phases.
+
+## Where to put `Kind` constants
+
+Two patterns in the tree:
+
+- **Shared registry** (`pkg/common/constant/`): most built-in filters
+  put their kind names there so other packages can import them
+  cleanly. Prefer this when the filter is being merged upstream.
+- **Package-local const**: fine for private / experimental filters.
+  Declare `const Kind = "dgp.filter.http.<name>"` in your file.
+
+Be consistent within a PR — do not mix.

--- a/skills/pixiu-filter-author/references/pluginregistry-howto.md
+++ b/skills/pixiu-filter-author/references/pluginregistry-howto.md
@@ -1,0 +1,92 @@
+# `pkg/pluginregistry/registry.go` — The Single Boot Activator
+
+This file exists because Go's `init()` only runs for packages that are
+**imported somewhere in the build graph**. Filters register themselves
+in `init()`, so unless something imports their package, the `init()`
+never runs and the registration never happens. `pluginregistry` is the
+one file that imports every filter/adapter/listener/lb package for side
+effects — a single central blank-import list — and `cmd/pixiu/` imports
+`pluginregistry`.
+
+## Shape of the file
+
+```go
+package pluginregistry
+
+import (
+    _ "github.com/apache/dubbo-go-pixiu/pkg/adapter/dubboregistry"
+    _ "github.com/apache/dubbo-go-pixiu/pkg/adapter/llmregistry"
+    _ "github.com/apache/dubbo-go-pixiu/pkg/adapter/mcpserver"
+    // ...
+    _ "github.com/apache/dubbo-go-pixiu/pkg/cluster/loadbalancer/maglev"
+    // ...
+    _ "github.com/apache/dubbo-go-pixiu/pkg/filter/accesslog"
+    _ "github.com/apache/dubbo-go-pixiu/pkg/filter/cors"
+    // ...
+    _ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/dubboproxy"
+    _ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/httpproxy"
+    // ...
+    _ "github.com/apache/dubbo-go-pixiu/pkg/listener/http"
+    // ...
+)
+```
+
+All imports are in one block. Entries are **alphabetical within each
+logical group** — adapters, lb, retry, filter (top-level),
+filter/http/, filter/network/, filter/auth/, listener. When adding,
+keep the alphabetical order *within* the group your package belongs to.
+
+## How to add an import
+
+For a new filter at `pkg/filter/mynewfilter/`:
+
+```go
+_ "github.com/apache/dubbo-go-pixiu/pkg/filter/mynewfilter"
+```
+
+Placement: in the top-level `pkg/filter/` group, alphabetically between
+`_ "github.com/apache/dubbo-go-pixiu/pkg/filter/metric"` and
+`_ "github.com/apache/dubbo-go-pixiu/pkg/filter/opa"` (or wherever
+`mynewfilter` sorts).
+
+For a new proxy-style filter at `pkg/filter/http/mynewproxy/`:
+
+```go
+_ "github.com/apache/dubbo-go-pixiu/pkg/filter/http/mynewproxy"
+```
+
+Placement: in the `pkg/filter/http/` group, alphabetically.
+
+## What happens if you forget
+
+- `go build ./...` — passes.
+- `go test ./pkg/filter/mynewfilter/...` — passes.
+- `./dubbo-go-pixiu gateway start -c configs/conf.yaml` — **fails at
+  config load** with `no filter found for name dgp.filter.http.mynew`.
+
+That boot-time error is the earliest signal. There is no compile-time
+check because the blank import is literally an import for side effects
+only.
+
+## Automating the check
+
+`scripts/gen-registry-import.sh` (in this skill) walks `pkg/filter/` and
+`pkg/filter/http/`, grep's each package for `filter.RegisterHttpFilter`
+or `filter.RegisterNetworkFilterPlugin`, and compares the resulting set
+against the blank-import list. It prints the missing lines. It does NOT
+edit the registry file — apply the diff by hand (this is a high-blast-
+radius file; a human should read the insertion point).
+
+Run it as the last step of every filter PR.
+
+## Why not a magic auto-registration?
+
+Two options have been proposed over the years:
+
+1. `go generate` a registry file from package tags.
+2. Reflect over package paths at runtime.
+
+Both were rejected because `pluginregistry` is also the list of
+**what gets built into the binary** — some deployments of pixiu ship a
+cut-down registry for supply-chain or binary-size reasons. Keeping the
+list explicit is a feature, not a bug.

--- a/skills/pixiu-filter-author/references/testing-patterns.md
+++ b/skills/pixiu-filter-author/references/testing-patterns.md
@@ -1,0 +1,137 @@
+# Testing a pixiu HTTP Filter (Optional)
+
+Tests in `pkg/filter/` are not uniform. As of pixiu 0.6, roughly half
+of the filter packages ship without `_test.go` — see SKILL.md Step 7
+for the exact split. This reference exists for the case **when you have
+decided** to write a test, so the new test fits the patterns the
+existing ones use.
+
+If your filter is a thin config-shaped wrapper (cors / csrf / jwt
+style), this file is not for you — skip the test entirely.
+
+## When a test is worth writing
+
+- The filter has branching logic on request shape (rate-limit decisions,
+  OPA policy results, conditional rewrites).
+- The filter mutates response bodies based on upstream output.
+- The filter has Apply()-time validation that should reject bad
+  configs.
+- You are debugging a specific issue and want a regression test
+  pinning the fix.
+
+If none of these apply, omit the test — the existing tree treats the
+boot-time integration check (filter loads, request flows) as sufficient
+for trivial filters.
+
+## The standard table-driven skeleton
+
+Use this layout when you do write a test. It mirrors the patterns used
+in `pkg/filter/sentinel/ratelimit/`, `pkg/filter/opa/`, and
+`pkg/filter/accesslog/`.
+
+```go
+package mynewfilter
+
+import (
+    "net/http"
+    "net/http/httptest"
+    "testing"
+
+    pixiuHttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
+    "github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestDecode(t *testing.T) {
+    tests := []struct {
+        name       string
+        reqHeaders map[string]string
+        cfg        *Config
+        wantStatus filter.FilterStatus
+        wantHeader map[string]string
+    }{
+        {
+            name:       "no-op when feature disabled",
+            reqHeaders: map[string]string{},
+            cfg:        &Config{Enabled: false},
+            wantStatus: filter.Continue,
+        },
+        {
+            name:       "adds tracing header when enabled",
+            reqHeaders: map[string]string{},
+            cfg:        &Config{Enabled: true},
+            wantStatus: filter.Continue,
+            wantHeader: map[string]string{"X-Trace": "yes"},
+        },
+    }
+
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            ctx := newTestCtx(tc.reqHeaders)
+            f := &Filter{cfg: tc.cfg}
+
+            got := f.Decode(ctx)
+            assert.Equal(t, tc.wantStatus, got)
+            for k, v := range tc.wantHeader {
+                assert.Equal(t, v, ctx.Request.Header.Get(k))
+            }
+        })
+    }
+}
+
+// newTestCtx builds a minimal HttpContext that is safe to exercise
+// for Decode-phase tests. For Encode-phase tests, also populate
+// ctx.SourceResp / ctx.TargetResp.
+func newTestCtx(headers map[string]string) *pixiuHttp.HttpContext {
+    req := httptest.NewRequest(http.MethodGet, "/probe", nil)
+    for k, v := range headers {
+        req.Header.Set(k, v)
+    }
+    rec := httptest.NewRecorder()
+
+    ctx := &pixiuHttp.HttpContext{
+        Request: req,
+        Writer:  rec,
+        Params:  map[string]any{},
+    }
+    return ctx
+}
+```
+
+`testify/assert` is the project default — pixiu's existing tests use
+it consistently.
+
+## Coverage expectations
+
+Pixiu's CI does not gate on a coverage number. The expectation in
+review is "tests cover the branches the code introduced" — not "every
+file has a test". Aim accordingly.
+
+## What to avoid
+
+- **Do not test `PrepareFilterChain` by itself.** It only appends to
+  the chain; the important behavior is in `Decode` / `Encode`.
+- **Do not test the blank import from Go test code.** Boot-time
+  smoke tests catch that; unit tests cannot.
+- **Do not pull in `pkg/server` or a real listener** to unit test a
+  filter — build the context by hand. If you find yourself wanting a
+  full server, you are writing an e2e test, which belongs elsewhere
+  (`integration/` if the user is targeting the upstream repo).
+- **Do not ship an empty test file as a placeholder.** Either include
+  real tests or omit the file.
+
+## Helpers worth stealing
+
+- `httptest.NewRequest` + `httptest.NewRecorder` are enough for most
+  Decode tests.
+- For response-body assertions in Encode, put the bytes directly into
+  `ctx.TargetResp` and call `f.Encode(ctx)`.
+- For filters that read `ctx.Params["user"]`, inject the expected
+  payload into the map before invoking — do not build a JWT.
+
+## Summary
+
+If you are not sure whether to test: look at the closest existing
+filter (similar complexity, similar shape) and copy its decision. The
+project's actual convention is "match the neighbors", not "always test"
+or "never test".

--- a/skills/pixiu-filter-author/scripts/gen-registry-import.sh
+++ b/skills/pixiu-filter-author/scripts/gen-registry-import.sh
@@ -27,19 +27,29 @@ while IFS= read -r gofile; do
   if grep -q -E 'filter\.RegisterHttpFilter|filter\.RegisterNetworkFilterPlugin' "$gofile" 2>/dev/null; then
     dir=$(dirname "$gofile")
     prefix="${ROOT}/"
-    rel="${dir#$prefix}"
+    rel="${dir#"$prefix"}"
     WANT+=("$MOD/$rel")
   fi
 done < <(find "$ROOT/pkg/filter" -type f -name '*.go' 2>/dev/null)
 
-# De-dup and sort.
-mapfile -t WANT < <(printf '%s\n' "${WANT[@]}" | sort -u)
+# De-dup and sort. Keep Bash 3 compatibility for macOS /bin/bash.
+declare -a WANT_UNIQ=()
+if [[ ${#WANT[@]} -gt 0 ]]; then
+  while IFS= read -r line; do
+    WANT_UNIQ+=("$line")
+  done < <(printf '%s\n' "${WANT[@]}" | sort -u)
+fi
+WANT=("${WANT_UNIQ[@]}")
 
 # Collect packages already blank-imported.
 declare -a HAVE=()
 while IFS= read -r line; do
   HAVE+=("$line")
-done < <(grep -oE '"[^"]+"' "$REG" | tr -d '"' | sort -u)
+done < <(
+  grep -oE '^[[:space:]]*_[[:space:]]+"[^"]+"' "$REG" \
+    | sed -E 's/^[[:space:]]*_[[:space:]]+"([^"]+)".*$/\1/' \
+    | sort -u
+)
 
 missing=()
 for p in "${WANT[@]}"; do

--- a/skills/pixiu-filter-author/scripts/gen-registry-import.sh
+++ b/skills/pixiu-filter-author/scripts/gen-registry-import.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# gen-registry-import.sh — find filter packages that are not blank-imported
+# into pkg/pluginregistry/registry.go.
+#
+# Usage: gen-registry-import.sh
+#
+# Run from the pixiu repo root, or pass PIXIU_ROOT=<path>.
+# The script never writes; it only prints the lines you should add and
+# exits non-zero when missing entries are found (useful for pre-commit).
+#
+set -euo pipefail
+
+ROOT="${PIXIU_ROOT:-$(pwd)}"
+REG="$ROOT/pkg/pluginregistry/registry.go"
+
+if [[ ! -f "$REG" ]]; then
+  echo "error: $REG not found; set PIXIU_ROOT=<pixiu-repo-path>" >&2
+  exit 1
+fi
+
+MOD="github.com/apache/dubbo-go-pixiu"
+
+# Collect packages that register a filter.
+declare -a WANT=()
+while IFS= read -r gofile; do
+  if grep -q -E 'filter\.RegisterHttpFilter|filter\.RegisterNetworkFilterPlugin' "$gofile" 2>/dev/null; then
+    dir=$(dirname "$gofile")
+    rel="${dir#$ROOT/}"
+    WANT+=("$MOD/$rel")
+  fi
+done < <(find "$ROOT/pkg/filter" -type f -name '*.go' 2>/dev/null)
+
+# De-dup and sort.
+mapfile -t WANT < <(printf '%s\n' "${WANT[@]}" | sort -u)
+
+# Collect packages already blank-imported.
+declare -a HAVE=()
+while IFS= read -r line; do
+  HAVE+=("$line")
+done < <(grep -oE '"[^"]+"' "$REG" | tr -d '"' | sort -u)
+
+missing=()
+for p in "${WANT[@]}"; do
+  found=0
+  for h in "${HAVE[@]}"; do
+    if [[ "$p" == "$h" ]]; then found=1; break; fi
+  done
+  if [[ $found -eq 0 ]]; then
+    missing+=("$p")
+  fi
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "OK: pluginregistry/registry.go covers every filter package under pkg/filter/."
+  exit 0
+fi
+
+echo "Missing blank imports in pkg/pluginregistry/registry.go:"
+echo ""
+for p in "${missing[@]}"; do
+  printf '\t_ "%s"\n' "$p"
+done
+echo ""
+echo "Add them in alphabetical order within the appropriate group, then rerun." >&2
+exit 2

--- a/skills/pixiu-filter-author/scripts/gen-registry-import.sh
+++ b/skills/pixiu-filter-author/scripts/gen-registry-import.sh
@@ -26,7 +26,8 @@ declare -a WANT=()
 while IFS= read -r gofile; do
   if grep -q -E 'filter\.RegisterHttpFilter|filter\.RegisterNetworkFilterPlugin' "$gofile" 2>/dev/null; then
     dir=$(dirname "$gofile")
-    rel="${dir#$ROOT/}"
+    prefix="${ROOT}/"
+    rel="${dir#$prefix}"
     WANT+=("$MOD/$rel")
   fi
 done < <(find "$ROOT/pkg/filter" -type f -name '*.go' 2>/dev/null)

--- a/skills/pixiu-filter-author/scripts/scaffold-filter.sh
+++ b/skills/pixiu-filter-author/scripts/scaffold-filter.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# scaffold-filter.sh — generate a minimal pixiu HTTP filter package.
+#
+# Usage:
+#   scaffold-filter.sh <name> [--proxy]
+#
+# Without --proxy: creates pkg/filter/<name>/<name>.go (single file).
+# With --proxy:    creates pkg/filter/http/<name>/{plugin.go,filter.go,config.go}.
+#
+# Run from the repo root, or pass PIXIU_ROOT=<path>.
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <name> [--proxy]" >&2
+  exit 1
+fi
+
+NAME="$1"
+KIND_PREFIX="dgp.filter.http"
+PROXY=0
+if [[ "${2:-}" == "--proxy" ]]; then
+  PROXY=1
+fi
+
+if [[ ! "$NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "error: name must be lowercase_snake_case" >&2
+  exit 1
+fi
+
+ROOT="${PIXIU_ROOT:-$(pwd)}"
+if [[ ! -f "$ROOT/go.mod" ]]; then
+  echo "error: $ROOT does not look like the pixiu repo root (no go.mod). Pass PIXIU_ROOT=<path>." >&2
+  exit 1
+fi
+
+if [[ $PROXY -eq 1 ]]; then
+  DIR="$ROOT/pkg/filter/http/$NAME"
+else
+  DIR="$ROOT/pkg/filter/$NAME"
+fi
+
+if [[ -e "$DIR" ]]; then
+  echo "error: $DIR already exists; aborting to avoid overwrite" >&2
+  exit 1
+fi
+
+mkdir -p "$DIR"
+
+KIND="${KIND_PREFIX}.${NAME}"
+PKG="$NAME"
+
+if [[ $PROXY -eq 1 ]]; then
+  # Split-file layout.
+  cat > "$DIR/plugin.go" <<EOF
+package ${PKG}
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
+)
+
+// Kind is the unique identifier for this filter in yaml.
+const Kind = "${KIND}"
+
+func init() {
+	filter.RegisterHttpFilter(&Plugin{})
+}
+
+type Plugin struct{}
+
+func (p *Plugin) Kind() string { return Kind }
+
+func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
+	return &FilterFactory{cfg: &Config{}}, nil
+}
+
+type FilterFactory struct {
+	cfg *Config
+}
+
+func (f *FilterFactory) Config() any   { return f.cfg }
+func (f *FilterFactory) Apply() error  { return nil }
+
+func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
+	inst := &Filter{cfg: *f.cfg}
+	chain.AppendDecodeFilters(inst)
+	return nil
+}
+EOF
+
+  cat > "$DIR/filter.go" <<EOF
+package ${PKG}
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
+)
+
+type Filter struct {
+	cfg Config
+}
+
+func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus {
+	// TODO: implement request-phase behavior.
+	return filter.Continue
+}
+EOF
+
+  cat > "$DIR/config.go" <<EOF
+package ${PKG}
+
+// Config holds the yaml-bound configuration for the ${NAME} filter.
+type Config struct {
+	// TODO: add yaml-tagged fields, e.g.:
+	// Enabled bool \`yaml:"enabled" json:"enabled" mapstructure:"enabled"\`
+}
+EOF
+
+else
+  # Single-file layout.
+  cat > "$DIR/${NAME}.go" <<EOF
+package ${PKG}
+
+import (
+	"github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	"github.com/apache/dubbo-go-pixiu/pkg/context/http"
+)
+
+// Kind is the unique identifier for this filter in yaml.
+const Kind = "${KIND}"
+
+func init() {
+	filter.RegisterHttpFilter(&Plugin{})
+}
+
+type (
+	Plugin        struct{}
+	FilterFactory struct{ cfg *Config }
+	Filter        struct{ cfg Config }
+	Config        struct {
+		// TODO: add yaml-tagged fields.
+	}
+)
+
+func (p *Plugin) Kind() string { return Kind }
+func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
+	return &FilterFactory{cfg: &Config{}}, nil
+}
+
+func (f *FilterFactory) Config() any  { return f.cfg }
+func (f *FilterFactory) Apply() error { return nil }
+func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
+	inst := &Filter{cfg: *f.cfg}
+	chain.AppendDecodeFilters(inst)
+	return nil
+}
+
+func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus {
+	// TODO: implement.
+	return filter.Continue
+}
+EOF
+fi
+
+echo "scaffolded $DIR"
+echo ""
+echo "Next steps:"
+echo "  1. Fill in Config fields + Apply() validation"
+echo "  2. Implement Decode (and/or add Encode + chain.AppendEncodeFilters)"
+echo "  3. Add blank import to pkg/pluginregistry/registry.go"
+echo "  4. Add config block under http_filters in configs/conf.yaml"
+echo "  5. (Optional) Write ${NAME}_test.go — only if your filter has branching logic worth testing; many existing filters (cors, csrf, jwt, httpproxy, ...) ship without tests."

--- a/skills/pixiu-filter-author/scripts/scaffold-filter.sh
+++ b/skills/pixiu-filter-author/scripts/scaffold-filter.sh
@@ -84,7 +84,7 @@ func (f *FilterFactory) Config() any   { return f.cfg }
 func (f *FilterFactory) Apply() error  { return nil }
 
 func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	inst := &Filter{cfg: *f.cfg}
+	inst := &Filter{cfg: f.cfg.DeepCopy()}
 	chain.AppendDecodeFilters(inst)
 	return nil
 }
@@ -99,7 +99,7 @@ import (
 )
 
 type Filter struct {
-	cfg Config
+	cfg *Config
 }
 
 func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus {
@@ -115,6 +115,16 @@ package ${PKG}
 type Config struct {
 	// TODO: add yaml-tagged fields, e.g.:
 	// Enabled bool \`yaml:"enabled" json:"enabled" mapstructure:"enabled"\`
+}
+
+// DeepCopy returns an independent per-request copy of Config.
+func (c *Config) DeepCopy() *Config {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	// TODO: explicitly clone any slices/maps/pointers added to Config.
+	return &cp
 }
 EOF
 
@@ -138,7 +148,7 @@ func init() {
 type (
 	Plugin        struct{}
 	FilterFactory struct{ cfg *Config }
-	Filter        struct{ cfg Config }
+	Filter        struct{ cfg *Config }
 	Config        struct {
 		// TODO: add yaml-tagged fields.
 	}
@@ -152,7 +162,7 @@ func (p *Plugin) CreateFilterFactory() (filter.HttpFilterFactory, error) {
 func (f *FilterFactory) Config() any  { return f.cfg }
 func (f *FilterFactory) Apply() error { return nil }
 func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.FilterChain) error {
-	inst := &Filter{cfg: *f.cfg}
+	inst := &Filter{cfg: f.cfg.DeepCopy()}
 	chain.AppendDecodeFilters(inst)
 	return nil
 }
@@ -160,6 +170,16 @@ func (f *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain filter.F
 func (f *Filter) Decode(ctx *http.HttpContext) filter.FilterStatus {
 	// TODO: implement.
 	return filter.Continue
+}
+
+// DeepCopy returns an independent per-request copy of Config.
+func (c *Config) DeepCopy() *Config {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	// TODO: explicitly clone any slices/maps/pointers added to Config.
+	return &cp
 }
 EOF
 fi

--- a/skills/pixiu-http-to-dubbo/SKILL.md
+++ b/skills/pixiu-http-to-dubbo/SKILL.md
@@ -31,7 +31,7 @@ the mapping rules in between.
 ## Two files, two jobs
 
 - **`conf.yaml`** (bootstrap) — wires the HTTP listener, enables the
-  `dgp.filter.http.httpconnectionmanager` network filter, and loads the
+  `dgp.filter.httpconnectionmanager` network filter, and loads the
   Dubbo registry adapter. You almost always keep this close to the
   sample; changes are listener port, adapter type, and sometimes
   cluster definitions.
@@ -249,7 +249,7 @@ target cluster explicitly:
 static_resources:
   clusters:
     - name: direct-dubbo
-      lb_policy: lb
+      lb_policy: RoundRobin
       endpoints:
         - id: direct-provider-1
           socket_address:
@@ -271,15 +271,17 @@ order matters — see `references/api-config-schema.md`.
 Run the bundled validator:
 
 ```sh
-bash scripts/validate-api-config.sh <path-to-api_config.yaml>
+bash "$(git rev-parse --show-toplevel)/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh" <path-to-api_config.yaml> [conf.yaml]
 ```
 
 It does:
 
 1. `yq` parse (catches yaml syntax errors).
 2. JSON Schema validation against
-   `references/api-config-schema.json` — catches unknown fields, wrong
-   types, missing required keys.
+   `references/api-config-schema.json` — catches unknown fields in
+   structured API mapping objects, wrong types, and missing required
+   keys. `filter.config` remains intentionally permissive because
+   individual filter plugins own their own config schemas.
 3. A sanity pass: every `clusterName` referenced in `integrationRequest`
    appears as an `id` / `name` in the adapters / clusters section of
    `conf.yaml` (if the user passes both files).

--- a/skills/pixiu-http-to-dubbo/SKILL.md
+++ b/skills/pixiu-http-to-dubbo/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: pixiu-http-to-dubbo
+description: |
+  Map a REST/HTTP endpoint onto a backend Dubbo service through
+  dubbo-go-pixiu. Use whenever the user wants to "expose Dubbo as HTTP",
+  "REST gateway for Dubbo", "Dubbo generic invoke", configure
+  `api_config.yaml`, `integrationRequest`, `mappingParams`, `mapType`,
+  `opt.types` / `opt.values`, group / version, or says "how do I call
+  my Dubbo service from curl".
+  Use this even when the user only asks to tweak an existing yaml route —
+  the combination of conf.yaml + api_config.yaml is where most "500 from
+  pixiu" reports come from, and this skill encodes the invariants.
+allowed-tools: [Read, Grep, Glob, Edit, Write, Bash]
+metadata:
+  version: "0.1.2"
+  domain: config
+  scope: generate-and-validate
+  triggers: ["http to dubbo", "REST to Dubbo", "Dubbo gateway", "api_config.yaml", "integrationRequest", "Dubbo generic invoke", "mappingParams", "mapType", "opt.types", "expose Dubbo as HTTP"]
+  pixiu_min_version: "0.6.0"
+  role: specialist
+---
+
+# pixiu-http-to-dubbo — Wiring HTTP Clients to Dubbo Backends
+
+pixiu's bread and butter is "let a REST client call a Dubbo service". On
+the surface it's two yaml files; underneath, you are configuring a
+generic Dubbo invoke, and most failures come from the three-way mismatch
+between the client request shape, the Dubbo interface signature, and
+the mapping rules in between.
+
+## Two files, two jobs
+
+- **`conf.yaml`** (bootstrap) — wires the HTTP listener, enables the
+  `dgp.filter.http.httpconnectionmanager` network filter, and loads the
+  Dubbo registry adapter. You almost always keep this close to the
+  sample; changes are listener port, adapter type, and sometimes
+  cluster definitions.
+- **`api_config.yaml`** — the per-endpoint mapping. One
+  `resources[].methods[]` entry per HTTP route. Every field except the
+  path comes from the Dubbo side; every mapping rule comes from the
+  HTTP side.
+
+This skill's job is to keep those two in sync.
+
+## When to Use
+
+Use this skill when the user wants to:
+- Expose an existing Dubbo interface through HTTP (GET/POST/PUT/DELETE).
+- Configure `integrationRequest` for an existing route.
+- Fix a 500 / "generic invoke failed" / "no provider found" error that
+  points at a yaml route.
+- Add parameter-name mapping (query → method param, body field → method
+  param, header → method param).
+- Switch an existing HTTP proxy route to Dubbo backend.
+
+**Do NOT use this skill for:**
+- Writing a new filter in the chain → `pixiu-filter-author`.
+- Adding a new registry adapter for a non-standard service registry —
+  out of scope; the user will need to author the adapter directly
+  against `pkg/common/extension/adapter/adapter.go`.
+- Pure yaml audit with no new HTTP-to-Dubbo route — out of scope. This
+  skill only validates the route/config fragments it generates or edits.
+
+## Prerequisites
+
+- pixiu ≥ 0.6.0.
+- A Dubbo provider running somewhere reachable. The user must know the
+  interface FQCN, method name, Java method signature, and the Dubbo
+  `group` / `version`.
+- A registry: ZooKeeper, Nacos, or an in-process ("direct URL")
+  endpoint. The registry configuration lives in `conf.yaml` under the
+  Dubbo adapter, not in `api_config.yaml`.
+
+## Steps
+
+### Step 0 — Verify Context
+
+1. Confirm pixiu version: `grep dubbo-go-pixiu go.mod`.
+2. Locate existing config: typically `configs/conf.yaml` and
+   `configs/api_config.yaml` in the pixiu repo, or user-specified
+   paths.
+3. Open `pkg/config/api_config.go` — that's the Go struct the yaml
+   actually binds to. Fields not present there are silently ignored;
+   always cross-reference. Current pixiu has `mappingParams` but no
+   top-level `paramTypes` field on `IntegrationRequest`, so do not
+   generate `paramTypes` unless a target version proves it exists.
+4. Open `pkg/client/dubbo/default.go`, `pkg/client/dubbo/mapper.go`,
+   and `pkg/client/dubbo/option.go` before editing mappings. They define
+   the accepted `mapTo` grammar and how `mapType` becomes the generic
+   invocation type list. Load `references/api-config-schema.md` for the
+   annotated view.
+5. If the user says "Dubbo direct URL, no registry", make sure you
+   understand they still need `clusters[]` in `conf.yaml` with the
+   provider address.
+
+### Step 1 — Gather the Seven Things (STOP and ask)
+
+You cannot write a valid `integrationRequest` without all of:
+
+1. **HTTP method + path**: `POST /api/v1/user`, etc.
+2. **Dubbo interface FQCN**: e.g. `com.example.UserProvider`.
+3. **Dubbo method name**: e.g. `createUser`.
+4. **Java method signature**: e.g.
+   `User createUser(com.example.User user)` or
+   `Page<Order> search(String tenant, OrderQuery q)`. Translate each
+   argument into a supported pixiu `mapType` (`string`, `int`, `long`,
+   `double`, `boolean`, `object`, etc.) rather than a top-level
+   `paramTypes` list.
+5. **Dubbo `group` and `version`**: empty strings are allowed but must
+   be explicit.
+6. **Where each parameter comes from** on the HTTP side: `queryStrings.
+   <name>`, `requestBody.<path>`, `headers.<name>`, `uri.<name>`.
+7. **Registry type**: ZK, Nacos, direct URL. This lives in `conf.yaml`.
+
+For POJO arguments, also ask whether the HTTP JSON body includes the
+Dubbo/Hessian class discriminator the provider expects, usually a
+`class` field such as `"class": "com.example.User"`. Pixiu can map the
+argument as `object`, but it cannot infer every provider-side POJO FQCN
+from a yaml field that the current config struct ignores.
+
+Read `references/param-mapping-rules.md` for the exact `mapTo` grammar
+and `references/generic-invoke-types.md` for the current `mapType` /
+`opt.types` conventions for primitives, collections, and nested POJOs.
+
+If the user says "direct URL", "no registry", or gives a provider
+address such as `10.0.0.8:20880`, keep the Dubbo route as
+`integrationRequest.requestType: dubbo` and put only `clusterName` in
+`api_config.yaml`. The provider address belongs in `conf.yaml` as a
+static/direct Dubbo cluster endpoint; do not copy it into the HTTP
+backend `url` / `host` / `path` fields.
+
+Do NOT proceed until all seven are answered. It is fine to propose
+defaults and ask for confirmation — but **every field must be explicit
+in the final yaml**.
+
+### Step 2 — Shape the `api_config.yaml` entry
+
+The template:
+
+```yaml
+name: pixiu
+description: <what this gateway does>
+resources:
+  - path: /api/v1/user
+    type: restful
+    description: create a user
+    methods:
+      - httpVerb: POST
+        enable: true
+        timeout: 1000ms
+        inboundRequest:
+          requestType: http
+          # describe the HTTP shape the client will send:
+          headers:
+            - name: X-Request-Id
+              required: false
+          queryStrings: []
+          requestBody:
+            - contentType: application/json
+              schema: user
+              required: true
+        integrationRequest:
+          requestType: dubbo
+          # Dubbo coordinates:
+          clusterName: dubbo-cluster          # matches conf.yaml clusters[].name
+          applicationName: pixiu
+          group: ""
+          version: "1.0.0"
+          interface: com.example.UserProvider
+          method: createUser
+          # How to pull each Dubbo method argument from the HTTP request:
+          mappingParams:
+            - name: requestBody
+              mapTo: "0"
+              mapType: object
+```
+
+Rules the template hides:
+
+- `requestType` **must** be `dubbo` for Dubbo routes. `http` is the
+  pass-through mode; different code path.
+- `mapTo` is either the **index** of the Dubbo method parameter
+  (`mapTo: "0"` is the first argument) or one of the supported
+  `opt.*` targets such as `opt.types`, `opt.values`, `opt.group`,
+  `opt.version`, `opt.interface`, `opt.application`, or `opt.method`.
+- `mapType` is the generic invoke type hint consumed by pixiu's Dubbo
+  mapper. Supported values come from `constant.JTypeMapper`: `string`,
+  `java.lang.String`, `char`, `short`, `int`, `long`, `float`,
+  `double`, `boolean`, `java.util.Date`, `date`, `object`, and
+  `java.lang.Object`. Use `object` / `java.lang.Object` for POJO or map
+  payloads, and include provider-required class metadata in the body
+  when the Dubbo serializer needs it.
+- Do not emit top-level `paramTypes` for current pixiu. Old examples may
+  contain it, but `pkg/config/api_config.go` does not bind it on
+  `IntegrationRequest`, so it is ignored unless the target branch proves
+  otherwise.
+- `clusterName` cross-references `conf.yaml`'s
+  `static_resources.clusters[].name`. A typo here = "cluster not found".
+
+For dynamic/default generic routes where the HTTP client explicitly
+sends the type list and value list, map body fields to `opt.types` and
+`opt.values` instead of using top-level yaml fields:
+
+```yaml
+mappingParams:
+  - name: requestBody.types
+    mapTo: opt.types
+  - name: requestBody.values
+    mapTo: opt.values
+```
+
+When the user pastes legacy `paramTypes`, `groupType`, or old
+`types/values` examples, translate the intent into current
+`mappingParams` and `mapType` rules. Do not preserve unknown fields just
+because the user supplied them; current `IntegrationRequest` silently
+ignores fields not present in `pkg/config/api_config.go`.
+
+### Step 3 — Update `conf.yaml` if needed
+
+You usually only touch `conf.yaml` when:
+
+- This is the first Dubbo route (need the Dubbo registry adapter).
+- A new `clusterName` is introduced.
+- A new listener port or host is needed.
+- The user wants direct/no-registry Dubbo access. In that case declare a
+  static/direct cluster endpoint in `conf.yaml` and keep
+  `api_config.yaml` focused on the Dubbo interface/method mapping.
+
+The Dubbo adapter block (ZK example):
+
+```yaml
+adapters:
+  - id: dubbo
+    name: dgp.adapter.dubboregistrycenter
+    config:
+      registries:
+        zk:
+          protocol: zookeeper
+          timeout: 3s
+          address: 127.0.0.1:2181
+          username: ""
+          password: ""
+```
+
+For direct/no-registry cases, omit the registry adapter and declare the
+target cluster explicitly:
+
+```yaml
+static_resources:
+  clusters:
+    - name: direct-dubbo
+      lb_policy: lb
+      endpoints:
+        - id: direct-provider-1
+          socket_address:
+            address: "10.0.0.8"
+            port: 20880
+```
+
+The matching `api_config.yaml` still uses
+`integrationRequest.clusterName: direct-dubbo`; it does not contain the
+provider URL.
+
+And the HTTP listener MUST have `dgp.filter.http.apiconfig` in its
+`http_filters` list, followed by `dgp.filter.http.dubboproxy` (or
+`dgp.filter.http.httpproxy` if some routes are pass-through). Filter
+order matters — see `references/api-config-schema.md`.
+
+### Step 4 — Validate
+
+Run the bundled validator:
+
+```sh
+bash scripts/validate-api-config.sh <path-to-api_config.yaml>
+```
+
+It does:
+
+1. `yq` parse (catches yaml syntax errors).
+2. JSON Schema validation against
+   `references/api-config-schema.json` — catches unknown fields, wrong
+   types, missing required keys.
+3. A sanity pass: every `clusterName` referenced in `integrationRequest`
+   appears as an `id` / `name` in the adapters / clusters section of
+   `conf.yaml` (if the user passes both files).
+
+If validation fails, fix *before* trying to boot pixiu — boot-time
+errors are more cryptic than the validator's messages.
+
+### Step 5 — Smoke Test
+
+1. `go run ./cmd/pixiu/... gateway start -c configs/conf.yaml -a configs/api_config.yaml`
+   (or the binary equivalent).
+2. `curl -v -X POST http://localhost:<port>/<path> ...`
+3. If you get HTTP 5xx, jump to `references/troubleshooting-500.md` —
+   it is organized by symptom.
+
+## Cross-Cutting Rules
+
+### Always
+
+- Base generated yaml on the current `pkg/config/api_config.go` and
+  `pkg/client/dubbo/*` code, not on older examples. If
+  `IntegrationRequest` has no `ParamTypes` field, treat top-level
+  `paramTypes` as legacy and do not generate it.
+- Use supported `mapType` values exactly as pixiu's `constant.JTypeMapper`
+  defines them. `String` and `bool` are not valid current-source values;
+  use `string` / `java.lang.String` and `boolean`.
+- Keep numeric `mappingParams[].mapTo` values aligned with Java method
+  argument order. `mapTo: "0"` is the first Dubbo argument.
+- Specify `group` and `version` explicitly, even if empty. Empty-string
+  is valid; missing key is not.
+- Put `dgp.filter.http.apiconfig` **before** any proxy filter in
+  `http_filters`.
+- Timeouts: give `methods[].timeout` a value shorter than the
+  listener's `idle_timeout` in `conf.yaml`.
+
+### Never
+
+- Generate top-level `paramTypes` for current pixiu unless Step 0 proves
+  the target branch has that field on `IntegrationRequest`.
+- Write `String` or `bool` as a `mapType`. Current pixiu accepts
+  `string` / `java.lang.String` and `boolean`.
+- Mix `requestType: http` and Dubbo fields in the same
+  `integrationRequest`. Pick one.
+- Put a Dubbo provider address in `integrationRequest.url`, `host`, or
+  `path`. Those fields belong to HTTP pass-through backends, not Dubbo
+  generic invoke routes.
+- Put the Dubbo registry configuration in `api_config.yaml`. It lives
+  in `conf.yaml` under `adapters`.
+- Use the literal object from the request body as a single arg when
+  the Dubbo side expects separate primitives. Use
+  `mappingParams[].mapTo` with an index per arg.
+
+## Common Pitfalls
+
+1. **`no provider found`** at boot — registry is up but the adapter
+   cannot resolve the interface. Check `interface`, `group`, `version`
+   spelling; `group` is case-sensitive.
+2. **500 with `generic invoke failed: ClassNotFound`** — type strings
+   came from legacy `paramTypes`, `opt.types`, or request body `types`
+   and do not match classes visible to the provider. For static routes,
+   prefer supported `mapType` keys and provider-required POJO class
+   metadata in the JSON body.
+3. **Response is `{}` / empty** — `mappingParams` is empty or wrong,
+   so the Dubbo method got `null` args and returned its default value.
+4. **Per-method timeout overridden by cluster timeout** —
+   `methods[].timeout` governs the Dubbo call deadline; the cluster's
+   `timeout` is the connection-level. If the Dubbo call is slow, bump
+   the method timeout first.
+5. **Header/query name case** — `inboundRequest.headers[].name` is
+   case-insensitive on match but case-sensitive in logs; normalize in
+   docs.
+6. **Nacos namespace confusion** — `namespace` vs `namespaceId` vs
+   `group` vs `groupName`. pixiu's Nacos adapter uses `namespace` and
+   `group`; if you are setting up a new adapter from scratch, read
+   the adapter source under `pkg/adapter/` for the actual field
+   names.
+
+## References
+
+| File | When to load |
+|---|---|
+| [references/api-config-schema.md](references/api-config-schema.md) | Step 0 and Step 2: annotated view of the Go struct backing `api_config.yaml`, with field-by-field notes |
+| [references/param-mapping-rules.md](references/param-mapping-rules.md) | Step 1–2: the `mappingParams.name` grammar (`queryStrings.*`, `requestBody.*`, `headers.*`, `uri.*`) and the `mapType` values |
+| [references/generic-invoke-types.md](references/generic-invoke-types.md) | Step 1–2: current `mapType` / `opt.types` rules for primitives, POJOs, enums, and nested objects |
+| [references/troubleshooting-500.md](references/troubleshooting-500.md) | Step 5 if a smoke test fails; ordered by symptom → root cause → fix |
+| [references/api-config-schema.json](references/api-config-schema.json) | Consumed by the validator script; does not need to be read directly |
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/validate-api-config.sh <api_config.yaml> [conf.yaml]` | yaml-parse, JSON-Schema-validate, and cross-file cluster-name sanity-check. Exits 0 on pass, non-zero with a grouped error report on failure. |

--- a/skills/pixiu-http-to-dubbo/references/api-config-schema.json
+++ b/skills/pixiu-http-to-dubbo/references/api-config-schema.json
@@ -4,21 +4,26 @@
   "title": "pixiu api_config.yaml",
   "type": "object",
   "required": ["name", "resources"],
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "name": { "type": "string" },
     "description": { "type": "string" },
+    "definitions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/definition" }
+    },
     "pluginFilePath": { "type": "string" },
     "pluginsGroup": {
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["groupName"],
         "properties": {
           "groupName": { "type": "string" },
           "plugins": {
             "type": "array",
-            "items": { "type": "object" }
+            "items": { "$ref": "#/definitions/pluginDeclaration" }
           }
         }
       }
@@ -32,18 +37,27 @@
     "resource": {
       "type": "object",
       "required": ["path", "methods"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
+        "id":          { "type": "integer" },
         "path":        { "type": "string", "pattern": "^/" },
         "type":        { "type": "string", "enum": ["restful"] },
         "description": { "type": "string" },
         "timeout":     { "type": "string", "pattern": "^\\d+(ms|s|m|h)$" },
-        "plugins": {
+        "filters": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/filter" }
+        },
+        "headers": {
           "type": "object",
-          "properties": {
-            "pre":  { "type": "object" },
-            "post": { "type": "object" }
-          }
+          "additionalProperties": { "type": "string" }
+        },
+        "resources": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/resource" }
+        },
+        "plugins": {
+          "$ref": "#/definitions/resourcePlugins"
         },
         "methods": {
           "type": "array",
@@ -54,8 +68,10 @@
     "method": {
       "type": "object",
       "required": ["httpVerb", "inboundRequest", "integrationRequest"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
+        "id": { "type": "integer" },
+        "resourcePath": { "type": "string" },
         "httpVerb": {
           "type": "string",
           "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
@@ -63,6 +79,11 @@
         "enable":  { "type": "boolean" },
         "onAir":   { "type": "boolean", "description": "Legacy examples use this name; current Method binds enable." },
         "timeout": { "type": "string", "pattern": "^\\d+(ms|s|m|h)$" },
+        "mock":    { "type": "boolean" },
+        "filters": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/filter" }
+        },
         "inboundRequest":     { "$ref": "#/definitions/inboundRequest" },
         "integrationRequest": { "$ref": "#/definitions/integrationRequest" }
       }
@@ -70,7 +91,7 @@
     "inboundRequest": {
       "type": "object",
       "required": ["requestType"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "requestType": { "type": "string", "enum": ["http"] },
         "headers":      { "type": "array", "items": { "$ref": "#/definitions/param" } },
@@ -79,6 +100,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "contentType": { "type": "string" },
               "schema":      { "type": "string" },
@@ -92,7 +114,7 @@
     "integrationRequest": {
       "type": "object",
       "required": ["requestType"],
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "requestType": { "type": "string", "enum": ["dubbo", "http"] },
         "clusterName":     { "type": "string" },
@@ -116,6 +138,7 @@
     "param": {
       "type": "object",
       "required": ["name"],
+      "additionalProperties": false,
       "properties": {
         "name":     { "type": "string" },
         "type":     { "type": "string" },
@@ -125,6 +148,7 @@
     "mappingParam": {
       "type": "object",
       "required": ["name", "mapTo"],
+      "additionalProperties": false,
       "properties": {
         "name":    { "type": "string" },
         "mapTo":   { "type": "string" },
@@ -146,6 +170,59 @@
             "java.lang.Object"
           ]
         }
+      }
+    },
+    "filter": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "config": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "resourcePlugins": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pre":  { "$ref": "#/definitions/pluginHook" },
+        "post": { "$ref": "#/definitions/pluginHook" }
+      }
+    },
+    "pluginHook": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "pluginNames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "groupNames": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "pluginDeclaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "priority": { "type": "integer" },
+        "externalLookupName": { "type": "string" }
+      }
+    },
+    "definition": {
+      "type": "object",
+      "required": ["name", "schema"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "schema": { "type": "string" }
       }
     }
   }

--- a/skills/pixiu-http-to-dubbo/references/api-config-schema.json
+++ b/skills/pixiu-http-to-dubbo/references/api-config-schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/apache/dubbo-go-pixiu/api-config.schema.json",
+  "title": "pixiu api_config.yaml",
+  "type": "object",
+  "required": ["name", "resources"],
+  "additionalProperties": true,
+  "properties": {
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "pluginFilePath": { "type": "string" },
+    "pluginsGroup": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["groupName"],
+        "properties": {
+          "groupName": { "type": "string" },
+          "plugins": {
+            "type": "array",
+            "items": { "type": "object" }
+          }
+        }
+      }
+    },
+    "resources": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/resource" }
+    }
+  },
+  "definitions": {
+    "resource": {
+      "type": "object",
+      "required": ["path", "methods"],
+      "additionalProperties": true,
+      "properties": {
+        "path":        { "type": "string", "pattern": "^/" },
+        "type":        { "type": "string", "enum": ["restful"] },
+        "description": { "type": "string" },
+        "timeout":     { "type": "string", "pattern": "^\\d+(ms|s|m|h)$" },
+        "plugins": {
+          "type": "object",
+          "properties": {
+            "pre":  { "type": "object" },
+            "post": { "type": "object" }
+          }
+        },
+        "methods": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/method" }
+        }
+      }
+    },
+    "method": {
+      "type": "object",
+      "required": ["httpVerb", "inboundRequest", "integrationRequest"],
+      "additionalProperties": true,
+      "properties": {
+        "httpVerb": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+        },
+        "enable":  { "type": "boolean" },
+        "onAir":   { "type": "boolean", "description": "Legacy examples use this name; current Method binds enable." },
+        "timeout": { "type": "string", "pattern": "^\\d+(ms|s|m|h)$" },
+        "inboundRequest":     { "$ref": "#/definitions/inboundRequest" },
+        "integrationRequest": { "$ref": "#/definitions/integrationRequest" }
+      }
+    },
+    "inboundRequest": {
+      "type": "object",
+      "required": ["requestType"],
+      "additionalProperties": true,
+      "properties": {
+        "requestType": { "type": "string", "enum": ["http"] },
+        "headers":      { "type": "array", "items": { "$ref": "#/definitions/param" } },
+        "queryStrings": { "type": "array", "items": { "$ref": "#/definitions/param" } },
+        "requestBody":  {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "contentType": { "type": "string" },
+              "schema":      { "type": "string" },
+              "required":    { "type": "boolean" },
+              "definitionName": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "integrationRequest": {
+      "type": "object",
+      "required": ["requestType"],
+      "additionalProperties": true,
+      "properties": {
+        "requestType": { "type": "string", "enum": ["dubbo", "http"] },
+        "clusterName":     { "type": "string" },
+        "applicationName": { "type": "string" },
+        "protocol": { "type": "string", "enum": ["dubbo", "tri", "triple", "grpc", "http", "https"] },
+        "group":     { "type": "string" },
+        "version":   { "type": "string" },
+        "interface": { "type": "string" },
+        "method":    { "type": "string" },
+        "retries":   { "type": "string" },
+        "mappingParams": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/mappingParam" }
+        },
+        "host":   { "type": "string" },
+        "path":   { "type": "string" },
+        "schema": { "type": "string", "enum": ["http", "https"] },
+        "url":    { "type": "string" }
+      }
+    },
+    "param": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name":     { "type": "string" },
+        "type":     { "type": "string" },
+        "required": { "type": "boolean" }
+      }
+    },
+    "mappingParam": {
+      "type": "object",
+      "required": ["name", "mapTo"],
+      "properties": {
+        "name":    { "type": "string" },
+        "mapTo":   { "type": "string" },
+        "mapType": {
+          "type": "string",
+          "enum": [
+            "string",
+            "java.lang.String",
+            "char",
+            "short",
+            "int",
+            "long",
+            "float",
+            "double",
+            "boolean",
+            "java.util.Date",
+            "date",
+            "object",
+            "java.lang.Object"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/skills/pixiu-http-to-dubbo/references/api-config-schema.md
+++ b/skills/pixiu-http-to-dubbo/references/api-config-schema.md
@@ -1,0 +1,172 @@
+# `api_config.yaml` — Annotated Schema
+
+Source of truth: `pkg/config/api_config.go` (types `APIConfig`,
+`Resource`, `Method`, `InboundRequest`, `IntegrationRequest`,
+`MappingParam`, `DubboBackendConfig`, `HTTPBackendConfig`). This
+document annotates the yaml fields that map to those types.
+
+## Top level
+
+```yaml
+name: <string>              # human-readable gateway name (free-form)
+description: <string>       # free-form
+resources:
+  - ...                     # one entry per HTTP path prefix / path
+pluginFilePath: ""          # rare; path to external Go plugin .so
+pluginsGroup:               # optional groups referenced from resources[].plugins
+  - groupName: ...
+    plugins: [...]
+```
+
+Only `name` and `resources` matter in practice. Everything else has
+workable defaults.
+
+## `resources[]`
+
+```yaml
+- path: /api/v1/user              # required; HTTP path to match
+  type: restful                   # required; "restful" is the common value
+  description: <free-form>
+  timeout: 500ms                  # resource-level default (methods override)
+  plugins:                        # optional pre/post plugin chains
+    pre:
+      pluginNames: [...]
+    post:
+      groupNames: [...]
+  methods:
+    - ...                         # one entry per HTTP verb
+```
+
+Path matching uses pixiu's router. Variables look like `/user/:id`.
+
+## `resources[].methods[]`
+
+This is where 90% of the configuration lives.
+
+```yaml
+- httpVerb: POST                  # GET/POST/PUT/DELETE/...
+  enable: true                    # false disables without removing
+  timeout: 1000ms                 # method-level; wins over resource-level
+  inboundRequest: ...
+  integrationRequest: ...
+```
+
+### `inboundRequest`
+
+Describes what the HTTP client sends. pixiu uses this for request
+validation (when `required: true`) and as the source for
+`mappingParams`.
+
+```yaml
+inboundRequest:
+  requestType: http               # only valid value today
+  headers:
+    - name: X-Trace-Id
+      required: false
+  queryStrings:
+    - name: userId
+      required: true
+  requestBody:
+    - contentType: application/json
+      schema: userCreateReq       # optional; references definitions
+      required: true
+```
+
+### `integrationRequest`
+
+Describes what pixiu sends upstream.
+
+For Dubbo:
+
+```yaml
+integrationRequest:
+  requestType: dubbo              # <- picks the Dubbo proxy path
+  # Dubbo backend fields (inlined from DubboBackendConfig):
+  clusterName: dubbo-cluster
+  applicationName: pixiu
+  protocol: dubbo                 # or "tri" for Triple
+  group: ""
+  version: 1.0.0
+  interface: com.example.UserProvider
+  method: createUser
+  retries: "0"                    # as string; "3" = three retries
+  # Arguments:
+  mappingParams:
+    - name: requestBody           # source on the HTTP side
+      mapTo: "0"                  # index into the Dubbo param list
+      mapType: object             # generic invoke type hint
+```
+
+For HTTP (pass-through):
+
+```yaml
+integrationRequest:
+  requestType: http
+  host: backend.example.com:8080
+  path: /internal/user            # rewrite; empty = keep inbound path
+  schema: http
+  mappingParams:                  # optional; map HTTP→HTTP fields
+    - name: queryStrings.name
+      mapTo: queryStrings.name
+```
+
+The two forms share the `requestType` key; that single value controls
+which code path pixiu takes. Mixing fields from both forms leads to the
+fields being silently ignored, not to a validation error — this is the
+single most common way to get a "500 with no obvious cause".
+
+## `mappingParams` grammar (summary)
+
+Source side (`name`):
+
+- `queryStrings.<qs-name>`
+- `requestBody.<jsonpath>` — dot-separated JSON path into the parsed body
+- `headers.<header-name>`
+- `uri.<path-var>` — matches `:id`-style variables in the route path
+
+Target side (`mapTo`):
+
+- For Dubbo: a **numeric index as a string**, matching the position in
+  the Java method signature. Start from `"0"`.
+- For Dubbo generic options: `opt.values`, `opt.types`, `opt.group`,
+  `opt.version`, `opt.interface`, `opt.application`, or `opt.method`.
+- For HTTP: a path in the downstream request, e.g.
+  `queryStrings.<name>`, `requestBody.<path>`.
+
+`mapType` values are the keys accepted by current
+`pkg/common/constant/jtypes.go`: `string`, `java.lang.String`, `char`,
+`short`, `int`, `long`, `float`, `double`, `boolean`,
+`java.util.Date`, `date`, `object`, and `java.lang.Object`. Use
+`object` / `java.lang.Object` for POJO or nested structures. If the
+Dubbo provider requires Hessian class metadata, include the class
+discriminator in the JSON body, for example `"class":
+"com.example.User"`.
+
+See `param-mapping-rules.md` for concrete worked examples.
+
+## What is NOT in the yaml
+
+- **Registry configuration** (ZK/Nacos addresses). Lives in
+  `conf.yaml`, under the Dubbo adapter.
+- **Filter chain order**. Lives in `conf.yaml`, under
+  `http_filters`.
+- **Authentication**. Handled by filters (JWT / bearer / OPA),
+  configured in `conf.yaml`.
+
+If the user tries to put any of these in `api_config.yaml`, the fields
+are ignored at load time without a warning.
+
+## Fields the Go struct does NOT have (do not use)
+
+The following keys have circulated in old samples and blog posts but
+are not recognized by current pixiu. If you see them, move the semantics
+elsewhere or delete.
+
+- `paramTypes` — old samples may include this under
+  `integrationRequest`, but current `IntegrationRequest` does not bind
+  it. For static routes, put the type hint in `mappingParams[].mapType`;
+  for dynamic generic routes, map a request field to `opt.types`.
+- `groupType` / `paramValues` — old style, replaced by
+  `mappingParams` plus `mapType` / `opt.types` / `opt.values`.
+- `authority` inside `integrationRequest` — move to a filter.
+- `interfaceName` — the correct key is `interface`.

--- a/skills/pixiu-http-to-dubbo/references/generic-invoke-types.md
+++ b/skills/pixiu-http-to-dubbo/references/generic-invoke-types.md
@@ -1,0 +1,125 @@
+# Dubbo Generic Invoke Type Hints
+
+Pixiu builds a Dubbo generic invocation from `mappingParams`. In the
+current source, the static type hint for each positional argument comes
+from `mappingParams[].mapType`, not from a top-level `paramTypes` field
+under `integrationRequest`.
+
+Before relying on any example, check:
+
+- `pkg/config/api_config.go` for the fields yaml actually binds.
+- `pkg/client/dubbo/mapper.go` for `mapTo` and `mapType` behavior.
+- `pkg/common/constant/jtypes.go` for accepted type strings.
+
+## Supported `mapType` Values
+
+Current `constant.JTypeMapper` accepts these keys:
+
+| Java intent | `mapType` to use |
+|---|---|
+| `String` | `string` or `java.lang.String` |
+| `char` / `Character` | `char` |
+| `short` / `Short` | `short` |
+| `int` / `Integer` | `int` |
+| `long` / `Long` | `long` |
+| `float` / `Float` | `float` |
+| `double` / `Double` | `double` |
+| `boolean` / `Boolean` | `boolean` |
+| `java.util.Date` | `java.util.Date` or `date` |
+| POJO / map-like object | `object` or `java.lang.Object` |
+
+Do not use `String`, `bool`, `array`, or arbitrary POJO FQCNs as
+`mapType` values unless Step 0 proves the target branch added them.
+
+## POJOs
+
+For a Java signature such as:
+
+```java
+User createUser(com.example.User user)
+```
+
+use a positional object mapping:
+
+```yaml
+mappingParams:
+  - name: requestBody
+    mapTo: "0"
+    mapType: object
+```
+
+Some provider-side serializers need class metadata in the JSON object:
+
+```json
+{ "class": "com.example.User", "id": 42, "name": "alice" }
+```
+
+Pixiu can pass the object as a generic map, but it cannot infer every
+provider-side FQCN from a top-level yaml field that the current config
+struct ignores. When in doubt, include the provider class discriminator
+in the body and verify against the real provider.
+
+## Multiple Arguments
+
+Keep numeric `mapTo` values aligned with the Java method parameter
+order:
+
+```java
+Page<Order> search(String tenant, com.example.OrderQuery query)
+```
+
+```yaml
+mappingParams:
+  - name: headers.X-Tenant
+    mapTo: "0"
+    mapType: string
+  - name: requestBody
+    mapTo: "1"
+    mapType: object
+```
+
+## Dynamic Generic Routes
+
+Pixiu also has a dynamic/default generic path where the HTTP request
+supplies values and type strings. Use this only when the client is
+expected to send that shape explicitly:
+
+```yaml
+mappingParams:
+  - name: requestBody.types
+    mapTo: opt.types
+  - name: requestBody.values
+    mapTo: opt.values
+```
+
+In this mode, type strings come from the HTTP request body and must be
+valid for the provider. A `ClassNotFoundException: String` usually means
+the request supplied `String` where the provider expected a class name
+or where the current static route should have used `mapType: string`
+instead.
+
+## Nested Objects and Enums
+
+Nested objects should carry their own class metadata when the provider's
+serializer expects it:
+
+```json
+{
+  "class": "com.example.order.Order",
+  "buyer": { "class": "com.example.user.User", "id": 1 }
+}
+```
+
+Enums are usually represented as objects or strings according to the
+provider contract. Preserve the provider's expected JSON/generic shape;
+`mapType: object` on the top-level argument is enough for Pixiu to pass
+the nested map through.
+
+## Quick Checklist
+
+- [ ] No top-level `integrationRequest.paramTypes` for current pixiu.
+- [ ] Every numeric `mapTo` matches the Java method argument position.
+- [ ] Every `mapType` is in `constant.JTypeMapper`.
+- [ ] POJO bodies include `class` metadata if the provider needs it.
+- [ ] Dynamic `opt.types` is used only when the client supplies the type
+  list at request time.

--- a/skills/pixiu-http-to-dubbo/references/param-mapping-rules.md
+++ b/skills/pixiu-http-to-dubbo/references/param-mapping-rules.md
@@ -1,0 +1,139 @@
+# Parameter Mapping Rules
+
+A Dubbo method call has an ordered argument list; an HTTP request has
+inputs spread across path variables, query strings, headers, and body.
+`mappingParams` is the translation layer.
+
+## Anatomy of One Entry
+
+```yaml
+- name: requestBody.user.email    # source: where to pull from HTTP
+  mapTo: "1"                      # target: Dubbo arg index or opt.* key
+  mapType: string                 # type hint for Dubbo mapping
+```
+
+For current pixiu, every static Dubbo argument should be represented by
+at least one `mappingParams` entry with numeric `mapTo`. There is no
+current-source top-level `paramTypes` field on `IntegrationRequest`.
+
+## `name` Source Grammar
+
+| Prefix | Means | Example source |
+|---|---|---|
+| `queryStrings.<qs>` | URL query string | `?name=alice` -> `queryStrings.name` -> `"alice"` |
+| `uri.<var>` | path variable | `/user/:id` matched by `/user/42` -> `uri.id` -> `"42"` |
+| `headers.<h>` | HTTP request header | `X-Tenant: acme` -> `headers.X-Tenant` -> `"acme"` |
+| `requestBody.<field>` | JSON body field | `{"user":{"name":"bob"}}` + `requestBody.user.name` -> `"bob"` |
+| `requestBody` | whole parsed body | Use when the Dubbo arg is a POJO mirroring the body |
+
+Rules:
+
+- `queryStrings.*`, `uri.*`, and `headers.*` normally produce strings;
+  use `mapType` to coerce them for numeric/boolean Dubbo arguments.
+- `requestBody.*` preserves the JSON shape: objects become maps,
+  arrays become slices, numbers remain JSON-decoded numbers.
+- The source path is evaluated after Pixiu has parsed the request.
+
+## `mapTo` Target Grammar
+
+For static Dubbo arguments, `mapTo` is a zero-based argument index as a
+string:
+
+```yaml
+mappingParams:
+  - { name: uri.id,           mapTo: "0", mapType: string }
+  - { name: queryStrings.n,   mapTo: "1", mapType: int }
+  - { name: requestBody.user, mapTo: "2", mapType: object }
+```
+
+For dynamic generic routes, `mapTo` can target Dubbo option fields:
+
+```yaml
+mappingParams:
+  - { name: requestBody.types,  mapTo: opt.types }
+  - { name: requestBody.values, mapTo: opt.values }
+  - { name: queryStrings.group, mapTo: opt.group }
+```
+
+Supported `opt.*` targets in current Pixiu include `opt.values`,
+`opt.types`, `opt.group`, `opt.version`, `opt.interface`,
+`opt.application`, and `opt.method`.
+
+For HTTP pass-through routes, `mapTo` is a dotted target path into the
+downstream request, such as `queryStrings.<name>`,
+`requestBody.<field>`, or `headers.<name>`.
+
+## `mapType` Values
+
+Use only values accepted by `pkg/common/constant/jtypes.go`:
+
+| `mapType` | Use for |
+|---|---|
+| `string` / `java.lang.String` | Java `String` |
+| `char` | Java `char` / `Character` |
+| `short` | Java `short` / `Short` |
+| `int` | Java `int` / `Integer` |
+| `long` | Java `long` / `Long` |
+| `float` | Java `float` / `Float` |
+| `double` | Java `double` / `Double` |
+| `boolean` | Java `boolean` / `Boolean` |
+| `java.util.Date` / `date` | Java date values |
+| `object` / `java.lang.Object` | POJO, map-like object, nested JSON object |
+
+Do not use `bool`, `array`, `String`, or arbitrary POJO FQCNs as
+`mapType` values for current pixiu.
+
+## Worked Examples
+
+### Example 1: Primitives From Query String
+
+Dubbo: `String greet(String name, int times, boolean loud)`
+
+```yaml
+mappingParams:
+  - { name: queryStrings.name,  mapTo: "0", mapType: string }
+  - { name: queryStrings.times, mapTo: "1", mapType: int }
+  - { name: queryStrings.loud,  mapTo: "2", mapType: boolean }
+```
+
+### Example 2: One POJO From Body
+
+Dubbo: `void createUser(User u)`
+
+```yaml
+mappingParams:
+  - { name: requestBody, mapTo: "0", mapType: object }
+```
+
+HTTP body if the provider requires class metadata:
+
+```json
+{ "class": "com.example.User", "name": "alice", "age": 42 }
+```
+
+### Example 3: Mixed Sources
+
+Dubbo: `Page<User> search(String tenant, Query q)`
+
+```yaml
+mappingParams:
+  - { name: headers.X-Tenant,  mapTo: "0", mapType: string }
+  - { name: requestBody.query, mapTo: "1", mapType: object }
+```
+
+`requestBody.query` means the HTTP body is shaped as
+`{"query": {...}}`; the Dubbo method receives the inner object.
+
+### Example 4: Dynamic Types and Values
+
+Use this only when the HTTP client intentionally supplies generic
+invoke payloads:
+
+```yaml
+mappingParams:
+  - { name: requestBody.types,  mapTo: opt.types }
+  - { name: requestBody.values, mapTo: opt.values }
+```
+
+The request body then owns correctness of the type strings. Static
+routes should prefer numeric `mapTo` plus `mapType`.

--- a/skills/pixiu-http-to-dubbo/references/troubleshooting-500.md
+++ b/skills/pixiu-http-to-dubbo/references/troubleshooting-500.md
@@ -1,0 +1,115 @@
+# HTTP-to-Dubbo — Troubleshooting by Symptom
+
+When the gateway returns a 5xx for a Dubbo-backed route, the failure is
+almost always in one of four places. Walk them in order.
+
+## Symptom: 404 "no route found"
+
+Not a Dubbo issue — the request did not match any `resources[].path`.
+
+Checks:
+
+- Path matches exactly (watch for trailing slashes).
+- `methods[].httpVerb` includes the method used.
+- `methods[].enable: true` (or omitted if the current loader defaults
+  it on).
+- `dgp.filter.http.apiconfig` is in the `http_filters` list in
+  `conf.yaml`. Without it, the api_config is not consulted.
+
+## Symptom: 500 `no filter found for name dgp.filter.http.XXX`
+
+Filter-registration issue. Apply the fix from `pixiu-filter-author`
+(missing blank import in `pkg/pluginregistry/registry.go`).
+
+## Symptom: 500 `no provider found`
+
+The registry adapter booted but the Dubbo `interface` / `group` /
+`version` combo is not registered. Check the three fields are spelled
+correctly in `integrationRequest`. `group` is case-sensitive and
+typically empty-string by default (`group: ""`) — the value `"default"`
+is not interchangeable with `""`.
+
+Also confirm the provider is registered to the *same* registry that the
+pixiu adapter points at. A ZK-registered provider will not be found via
+a Nacos adapter and vice versa.
+
+## Symptom: 500 `generic invoke failed: ClassNotFoundException`
+
+Pixiu or the request supplied a type string the provider cannot load.
+In current static routes, the first place to check is
+`mappingParams[].mapType`; for dynamic/default generic routes, check
+request fields mapped to `opt.types` / `opt.values`. Old configs may
+also contain top-level `paramTypes`, but current `IntegrationRequest`
+does not bind that field.
+
+Usual offenders:
+
+- `mapType: String` instead of `mapType: string` or
+  `mapType: java.lang.String`.
+- `mapType: bool` instead of `mapType: boolean`.
+- A dynamic `requestBody.types` entry containing `String` when the
+  provider expects a loadable Java class name.
+- POJO body missing provider-required `"class": "com.example.User"`
+  metadata.
+- User POJO with a misspelled package path or absent provider class.
+
+See `generic-invoke-types.md` for the current `mapType` table.
+
+## Symptom: 500 `generic invoke failed: ... NullPointerException`
+
+The Dubbo method got called, but with `null` arguments. Root causes:
+
+- `mappingParams` missing an entry with the expected `mapTo: "<i>"`.
+- `name` selector references a field the request does not contain —
+  e.g. `queryStrings.userId` but the request has `user_id`.
+- `requestBody.<path>` dotted path does not match the actual JSON
+  structure.
+- Body `content-type` is not `application/json` and the body was not
+  parsed.
+
+Quick check: `curl -v` the request and confirm the body shape; then
+walk `mappingParams` rule-by-rule.
+
+## Symptom: 500 with `io.netty.handler.timeout.ReadTimeoutException`
+
+Dubbo call is slower than the configured timeout. Two timeouts in play:
+
+- `methods[].timeout` in `api_config.yaml` — the Dubbo RPC deadline.
+- `listeners[].config.{read_timeout,write_timeout}` in `conf.yaml` —
+  the HTTP deadline.
+
+Bump `methods[].timeout` first. If you bump past the HTTP deadline, the
+client will see a different error.
+
+## Symptom: empty `{}` response, no error in logs
+
+Dubbo call succeeded but pixiu could not serialize the result. Usually:
+
+- The Dubbo method returns a POJO that uses Hessian serialization
+  annotations the generic invoke serializer does not know about.
+- The Dubbo method returns `void` and pixiu serialized `null` as
+  `{}` — expected behavior, not a bug.
+
+## Symptom: request hangs forever
+
+Connection / routing issue, not a pixiu-config issue:
+
+- `clusterName` in `integrationRequest` does not match any
+  `static_resources.clusters[].name` in `conf.yaml`. This sometimes
+  produces silent hangs depending on pixiu version.
+- The Dubbo provider is reachable from the gateway host? (Different
+  subnet, firewall, k8s NetworkPolicy.)
+- The registry adapter is in `CONNECTING` state. Check pixiu logs for
+  adapter warnings.
+
+## Workflow for an unknown 500
+
+1. `curl -v` the failing request; record the response.
+2. `docker logs pixiu | grep -iE 'error|warn|fail' | tail -50` — look
+   for the first error line. Pixiu logs tend to be verbose; the first
+   error line near the request timestamp is the root.
+3. Match the error substring against the sections above.
+4. If no match, enable debug logging (`log.level: debug` in
+   `conf.yaml`) and repeat.
+5. Before editing yaml, run `bash scripts/validate-api-config.sh` — it
+   catches structural mistakes the logs will not be specific about.

--- a/skills/pixiu-http-to-dubbo/references/troubleshooting-500.md
+++ b/skills/pixiu-http-to-dubbo/references/troubleshooting-500.md
@@ -3,6 +3,10 @@
 When the gateway returns a 5xx for a Dubbo-backed route, the failure is
 almost always in one of four places. Walk them in order.
 
+The detailed exception strings below are **server-log signatures** to
+search in Pixiu logs, not response text to expose to clients. Keep
+client-facing 5xx bodies generic; log internal details server-side.
+
 ## Symptom: 404 "no route found"
 
 Not a Dubbo issue — the request did not match any `resources[].path`.
@@ -16,12 +20,12 @@ Checks:
 - `dgp.filter.http.apiconfig` is in the `http_filters` list in
   `conf.yaml`. Without it, the api_config is not consulted.
 
-## Symptom: 500 `no filter found for name dgp.filter.http.XXX`
+## Symptom: 500; log signature `no filter found for name dgp.filter.http.XXX`
 
 Filter-registration issue. Apply the fix from `pixiu-filter-author`
 (missing blank import in `pkg/pluginregistry/registry.go`).
 
-## Symptom: 500 `no provider found`
+## Symptom: 500; log signature `no provider found`
 
 The registry adapter booted but the Dubbo `interface` / `group` /
 `version` combo is not registered. Check the three fields are spelled
@@ -33,7 +37,7 @@ Also confirm the provider is registered to the *same* registry that the
 pixiu adapter points at. A ZK-registered provider will not be found via
 a Nacos adapter and vice versa.
 
-## Symptom: 500 `generic invoke failed: ClassNotFoundException`
+## Symptom: 500; log signature `generic invoke failed: ClassNotFoundException`
 
 Pixiu or the request supplied a type string the provider cannot load.
 In current static routes, the first place to check is
@@ -55,7 +59,7 @@ Usual offenders:
 
 See `generic-invoke-types.md` for the current `mapType` table.
 
-## Symptom: 500 `generic invoke failed: ... NullPointerException`
+## Symptom: 500; log signature `generic invoke failed: ... NullPointerException`
 
 The Dubbo method got called, but with `null` arguments. Root causes:
 
@@ -70,7 +74,7 @@ The Dubbo method got called, but with `null` arguments. Root causes:
 Quick check: `curl -v` the request and confirm the body shape; then
 walk `mappingParams` rule-by-rule.
 
-## Symptom: 500 with `io.netty.handler.timeout.ReadTimeoutException`
+## Symptom: 500; log signature `io.netty.handler.timeout.ReadTimeoutException`
 
 Dubbo call is slower than the configured timeout. Two timeouts in play:
 
@@ -111,5 +115,6 @@ Connection / routing issue, not a pixiu-config issue:
 3. Match the error substring against the sections above.
 4. If no match, enable debug logging (`log.level: debug` in
    `conf.yaml`) and repeat.
-5. Before editing yaml, run `bash scripts/validate-api-config.sh` — it
-   catches structural mistakes the logs will not be specific about.
+5. Before editing yaml, run
+   `bash "$(git rev-parse --show-toplevel)/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh" <api_config.yaml> [conf.yaml]` —
+   it catches structural mistakes the logs will not be specific about.

--- a/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
+++ b/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
@@ -22,7 +22,7 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
+    ruby -ryaml -rjson -e 'begin; puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false)); rescue StandardError => e; warn "#{e.class}: #{e.message}"; exit 1; end' "$file"
   else
     return 127
   fi
@@ -61,16 +61,27 @@ trap cleanup EXIT
 
 section() { echo; echo "== $* =="; }
 
+json_from_yaml() {
+  local src="$1"
+  local dst="$2"
+  local label="$3"
+  local err
+  err=$(mktemp -t pixiu-yaml-XXXXXX)
+  tmp_files+=("$err")
+  if yaml_to_json "$src" > "$dst" 2>"$err"; then
+    return 0
+  fi
+  echo "  FAIL: unable to parse $label:"
+  cat "$err"
+  exit 2
+}
+
 section "1. YAML syntax"
 if has_yaml_reader; then
-  yaml_err=$(mktemp -t pixiu-api-yaml-XXXXXX)
-  tmp_files+=("$yaml_err")
-  if yaml_to_json "$API_CFG" > /dev/null 2>"$yaml_err"; then
-    echo "  OK"
-  else
-    echo "  FAIL:"; cat "$yaml_err"
-    errors=$((errors+1))
-  fi
+  syntax_json=$(mktemp -t pixiu-api-syntax-XXXXXX.json)
+  tmp_files+=("$syntax_json")
+  json_from_yaml "$API_CFG" "$syntax_json" "$API_CFG"
+  echo "  OK"
 else
   echo "  SKIP (install yq or ruby)"
 fi
@@ -81,7 +92,7 @@ if command -v ajv >/dev/null 2>&1 && has_yaml_reader; then
   tmp_files+=("$tmpjson")
   ajv_out=$(mktemp -t pixiu-api-ajv-XXXXXX)
   tmp_files+=("$ajv_out")
-  yaml_to_json "$API_CFG" > "$tmpjson"
+  json_from_yaml "$API_CFG" "$tmpjson" "$API_CFG"
   if ajv validate --spec=draft7 -s "$SCHEMA" -d "$tmpjson" > "$ajv_out" 2>&1; then
     echo "  OK"
   else
@@ -96,7 +107,7 @@ section "3. Legacy top-level paramTypes"
 if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
   tmp_files+=("$tmpjson")
-  yaml_to_json "$API_CFG" > "$tmpjson"
+  json_from_yaml "$API_CFG" "$tmpjson" "$API_CFG"
   legacy=$(python3 - "$tmpjson" <<'PY'
 import json
 import sys
@@ -138,7 +149,7 @@ section "4. mappingParams mapTo/mapType sanity"
 if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
   tmp_files+=("$tmpjson")
-  yaml_to_json "$API_CFG" > "$tmpjson"
+  json_from_yaml "$API_CFG" "$tmpjson" "$API_CFG"
   map_errors=$(python3 - "$tmpjson" <<'PY'
 import json
 import re
@@ -230,8 +241,8 @@ if [[ -n "$CONF_CFG" ]]; then
     api_json=$(mktemp -t pixiu-api-XXXXXX.json)
     conf_json=$(mktemp -t pixiu-conf-XXXXXX.json)
     tmp_files+=("$api_json" "$conf_json")
-    yaml_to_json "$API_CFG" > "$api_json"
-    yaml_to_json "$CONF_CFG" > "$conf_json"
+    json_from_yaml "$API_CFG" "$api_json" "$API_CFG"
+    json_from_yaml "$CONF_CFG" "$conf_json" "$CONF_CFG"
     missing=$(python3 - "$api_json" "$conf_json" <<'PY'
 import json
 import sys

--- a/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
+++ b/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# validate-api-config.sh — structural validation for pixiu's api_config.yaml.
+#
+# Usage:
+#   validate-api-config.sh <api_config.yaml> [conf.yaml]
+#
+# Uses:
+#   - yq (https://github.com/mikefarah/yq) for yaml parsing
+#   - ajv-cli (npm install -g ajv-cli) for JSON Schema validation
+#
+# If either is missing, the script reports what to install and falls
+# back to the checks it can still perform.
+#
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEMA="$HERE/../references/api-config-schema.json"
+
+yaml_to_json() {
+  local file="$1"
+  if command -v yq >/dev/null 2>&1; then
+    yq -o json eval '.' "$file"
+  elif command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+  else
+    return 127
+  fi
+}
+
+has_yaml_reader() {
+  command -v yq >/dev/null 2>&1 || command -v ruby >/dev/null 2>&1
+}
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <api_config.yaml> [conf.yaml]" >&2
+  exit 1
+fi
+
+API_CFG="$1"
+CONF_CFG="${2:-}"
+
+if [[ ! -f "$API_CFG" ]]; then
+  echo "error: $API_CFG not found" >&2
+  exit 1
+fi
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "error: schema $SCHEMA not found; is the skill directory intact?" >&2
+  exit 1
+fi
+
+errors=0
+
+section() { echo; echo "== $* =="; }
+
+section "1. YAML syntax"
+if has_yaml_reader; then
+  if yaml_to_json "$API_CFG" > /dev/null 2>/tmp/yaml.err; then
+    echo "  OK"
+  else
+    echo "  FAIL:"; cat /tmp/yaml.err
+    errors=$((errors+1))
+  fi
+else
+  echo "  SKIP (install yq or ruby)"
+fi
+
+section "2. JSON Schema conformance"
+if command -v ajv >/dev/null 2>&1 && has_yaml_reader; then
+  tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  yaml_to_json "$API_CFG" > "$tmpjson"
+  if ajv validate --spec=draft7 -s "$SCHEMA" -d "$tmpjson" > /tmp/ajv.out 2>&1; then
+    echo "  OK"
+  else
+    echo "  FAIL:"; cat /tmp/ajv.out
+    errors=$((errors+1))
+  fi
+  rm -f "$tmpjson"
+else
+  echo "  SKIP (install: npm i -g ajv-cli; yq or ruby for yaml parsing)"
+fi
+
+section "3. Legacy top-level paramTypes"
+if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
+  tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  yaml_to_json "$API_CFG" > "$tmpjson"
+  legacy=$(python3 - "$tmpjson" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+hits = []
+
+def walk(node, trail):
+    if isinstance(node, dict):
+        if "paramTypes" in node:
+            hits.append(".".join(trail + ["paramTypes"]))
+        for key, value in node.items():
+            walk(value, trail + [str(key)])
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            walk(value, trail + [str(i)])
+
+walk(data, [])
+print("\n".join(hits))
+PY
+)
+  rm -f "$tmpjson"
+  if [[ -n "$legacy" ]]; then
+    echo "  FAIL: current pixiu IntegrationRequest does not bind top-level paramTypes:"
+    echo "$legacy" | sed 's/^/    - /'
+    echo "  (use mappingParams[].mapType for static args, or opt.types for dynamic generic routes)"
+    errors=$((errors+1))
+  else
+    echo "  OK"
+  fi
+else
+  echo "  SKIP (install python3 plus yq or ruby)"
+fi
+
+section "4. mappingParams mapTo/mapType sanity"
+if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
+  tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  yaml_to_json "$API_CFG" > "$tmpjson"
+  map_errors=$(python3 - "$tmpjson" <<'PY'
+import json
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+allowed_map_types = {
+    "string",
+    "java.lang.String",
+    "char",
+    "short",
+    "int",
+    "long",
+    "float",
+    "double",
+    "boolean",
+    "java.util.Date",
+    "date",
+    "object",
+    "java.lang.Object",
+}
+allowed_opt = {
+    "opt.values",
+    "opt.types",
+    "opt.group",
+    "opt.version",
+    "opt.interface",
+    "opt.application",
+    "opt.method",
+}
+index_re = re.compile(r"^\d+$")
+errors = []
+
+def check_mapping(mapping, trail):
+    map_to = str(mapping.get("mapTo", ""))
+    if not (index_re.match(map_to) or map_to in allowed_opt):
+        errors.append(f"{trail}.mapTo={map_to!r} is not a numeric index or supported opt.* target")
+    map_type = mapping.get("mapType")
+    if map_type not in (None, "") and str(map_type) not in allowed_map_types:
+        errors.append(f"{trail}.mapType={map_type!r} is not in current JTypeMapper")
+
+def walk(node, trail):
+    if isinstance(node, dict):
+        mappings = node.get("mappingParams")
+        if isinstance(mappings, list):
+            for i, mapping in enumerate(mappings):
+                if isinstance(mapping, dict):
+                    check_mapping(mapping, ".".join(trail + ["mappingParams", str(i)]))
+        for key, value in node.items():
+            walk(value, trail + [str(key)])
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            walk(value, trail + [str(i)])
+
+walk(data, [])
+print("\n".join(errors))
+PY
+)
+  rm -f "$tmpjson"
+  if [[ -n "$map_errors" ]]; then
+    echo "  FAIL:"
+    echo "$map_errors" | sed 's/^/    - /'
+    errors=$((errors+1))
+  else
+    echo "  OK"
+  fi
+else
+  echo "  SKIP (install python3 plus yq or ruby)"
+fi
+
+section "5. clusterName cross-check against conf.yaml"
+if [[ -n "$CONF_CFG" ]]; then
+  if [[ ! -f "$CONF_CFG" ]]; then
+    echo "  SKIP (conf.yaml path $CONF_CFG not found)"
+  elif ! has_yaml_reader || ! command -v python3 >/dev/null 2>&1; then
+    echo "  SKIP (install python3 plus yq or ruby)"
+  else
+    api_json=$(mktemp -t pixiu-api-XXXXXX.json)
+    conf_json=$(mktemp -t pixiu-conf-XXXXXX.json)
+    yaml_to_json "$API_CFG" > "$api_json"
+    yaml_to_json "$CONF_CFG" > "$conf_json"
+    missing=$(python3 - "$api_json" "$conf_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    api = json.load(f)
+with open(sys.argv[2], "r", encoding="utf-8") as f:
+    conf = json.load(f)
+
+refs = set()
+
+def walk(node):
+    if isinstance(node, dict):
+        value = node.get("clusterName")
+        if value:
+            refs.add(str(value))
+        for child in node.values():
+            walk(child)
+    elif isinstance(node, list):
+        for child in node:
+            walk(child)
+
+walk(api)
+
+clusters = (((conf or {}).get("static_resources") or {}).get("clusters") or [])
+declared = {str(c.get("name")) for c in clusters if isinstance(c, dict) and c.get("name")}
+print(" ".join(sorted(refs - declared)))
+PY
+)
+    rm -f "$api_json" "$conf_json"
+    if [[ -n "$missing" ]]; then
+      echo "  FAIL: clusterName(s) referenced but not declared in conf.yaml:$missing"
+      errors=$((errors+1))
+    else
+      echo "  OK"
+    fi
+  fi
+else
+  echo "  SKIP (pass conf.yaml as 2nd arg to enable)"
+fi
+
+echo
+if [[ $errors -eq 0 ]]; then
+  echo "Validation passed."
+  exit 0
+else
+  echo "Validation failed with $errors error group(s)."
+  exit 2
+fi

--- a/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
+++ b/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
@@ -108,7 +108,10 @@ if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
   tmp_files+=("$tmpjson")
   json_from_yaml "$API_CFG" "$tmpjson" "$API_CFG"
-  legacy=$(python3 - "$tmpjson" <<'PY'
+  py_err=$(mktemp -t pixiu-api-python-XXXXXX)
+  tmp_files+=("$py_err")
+  legacy_failed=0
+  legacy=$(python3 - "$tmpjson" 2>"$py_err" <<'PY'
 import json
 import sys
 
@@ -131,14 +134,19 @@ def walk(node, trail):
 walk(data, [])
 print("\n".join(hits))
 PY
-)
-  if [[ -n "$legacy" ]]; then
+) || {
+    echo "  FAIL: legacy paramTypes helper failed:"
+    cat "$py_err"
+    errors=$((errors+1))
+    legacy_failed=1
+  }
+  if [[ $legacy_failed -eq 0 && -n "$legacy" ]]; then
     echo "  FAIL: current pixiu IntegrationRequest does not bind top-level paramTypes:"
     formatted="    - ${legacy//$'\n'/$'\n    - '}"
     printf '%s\n' "$formatted"
     echo "  (use mappingParams[].mapType for static args, or opt.types for dynamic generic routes)"
     errors=$((errors+1))
-  else
+  elif [[ $legacy_failed -eq 0 ]]; then
     echo "  OK"
   fi
 else
@@ -150,7 +158,10 @@ if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
   tmp_files+=("$tmpjson")
   json_from_yaml "$API_CFG" "$tmpjson" "$API_CFG"
-  map_errors=$(python3 - "$tmpjson" <<'PY'
+  py_err=$(mktemp -t pixiu-api-python-XXXXXX)
+  tmp_files+=("$py_err")
+  map_failed=0
+  map_errors=$(python3 - "$tmpjson" 2>"$py_err" <<'PY'
 import json
 import re
 import sys
@@ -218,13 +229,18 @@ def walk(node, trail):
 walk(data, [])
 print("\n".join(errors))
 PY
-)
-  if [[ -n "$map_errors" ]]; then
+) || {
+    echo "  FAIL: mappingParams helper failed:"
+    cat "$py_err"
+    errors=$((errors+1))
+    map_failed=1
+  }
+  if [[ $map_failed -eq 0 && -n "$map_errors" ]]; then
     echo "  FAIL:"
     formatted="    - ${map_errors//$'\n'/$'\n    - '}"
     printf '%s\n' "$formatted"
     errors=$((errors+1))
-  else
+  elif [[ $map_failed -eq 0 ]]; then
     echo "  OK"
   fi
 else
@@ -243,7 +259,10 @@ if [[ -n "$CONF_CFG" ]]; then
     tmp_files+=("$api_json" "$conf_json")
     json_from_yaml "$API_CFG" "$api_json" "$API_CFG"
     json_from_yaml "$CONF_CFG" "$conf_json" "$CONF_CFG"
-    missing=$(python3 - "$api_json" "$conf_json" <<'PY'
+    py_err=$(mktemp -t pixiu-api-python-XXXXXX)
+    tmp_files+=("$py_err")
+    missing_failed=0
+    missing=$(python3 - "$api_json" "$conf_json" 2>"$py_err" <<'PY'
 import json
 import sys
 
@@ -271,11 +290,16 @@ clusters = (((conf or {}).get("static_resources") or {}).get("clusters") or [])
 declared = {str(c.get("name")) for c in clusters if isinstance(c, dict) and c.get("name")}
 print(" ".join(sorted(refs - declared)))
 PY
-)
-    if [[ -n "$missing" ]]; then
+    ) || {
+      echo "  FAIL: clusterName cross-check helper failed:"
+      cat "$py_err"
+      errors=$((errors+1))
+      missing_failed=1
+    }
+    if [[ $missing_failed -eq 0 && -n "$missing" ]]; then
       echo "  FAIL: clusterName(s) referenced but not declared in conf.yaml:$missing"
       errors=$((errors+1))
-    else
+    elif [[ $missing_failed -eq 0 ]]; then
       echo "  OK"
     fi
   fi

--- a/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
+++ b/skills/pixiu-http-to-dubbo/scripts/validate-api-config.sh
@@ -22,7 +22,7 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
   else
     return 127
   fi
@@ -50,15 +50,25 @@ if [[ ! -f "$SCHEMA" ]]; then
 fi
 
 errors=0
+tmp_files=()
+
+cleanup() {
+  if [[ ${#tmp_files[@]} -gt 0 ]]; then
+    rm -f "${tmp_files[@]}"
+  fi
+}
+trap cleanup EXIT
 
 section() { echo; echo "== $* =="; }
 
 section "1. YAML syntax"
 if has_yaml_reader; then
-  if yaml_to_json "$API_CFG" > /dev/null 2>/tmp/yaml.err; then
+  yaml_err=$(mktemp -t pixiu-api-yaml-XXXXXX)
+  tmp_files+=("$yaml_err")
+  if yaml_to_json "$API_CFG" > /dev/null 2>"$yaml_err"; then
     echo "  OK"
   else
-    echo "  FAIL:"; cat /tmp/yaml.err
+    echo "  FAIL:"; cat "$yaml_err"
     errors=$((errors+1))
   fi
 else
@@ -68,14 +78,16 @@ fi
 section "2. JSON Schema conformance"
 if command -v ajv >/dev/null 2>&1 && has_yaml_reader; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  tmp_files+=("$tmpjson")
+  ajv_out=$(mktemp -t pixiu-api-ajv-XXXXXX)
+  tmp_files+=("$ajv_out")
   yaml_to_json "$API_CFG" > "$tmpjson"
-  if ajv validate --spec=draft7 -s "$SCHEMA" -d "$tmpjson" > /tmp/ajv.out 2>&1; then
+  if ajv validate --spec=draft7 -s "$SCHEMA" -d "$tmpjson" > "$ajv_out" 2>&1; then
     echo "  OK"
   else
-    echo "  FAIL:"; cat /tmp/ajv.out
+    echo "  FAIL:"; cat "$ajv_out"
     errors=$((errors+1))
   fi
-  rm -f "$tmpjson"
 else
   echo "  SKIP (install: npm i -g ajv-cli; yq or ruby for yaml parsing)"
 fi
@@ -83,6 +95,7 @@ fi
 section "3. Legacy top-level paramTypes"
 if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  tmp_files+=("$tmpjson")
   yaml_to_json "$API_CFG" > "$tmpjson"
   legacy=$(python3 - "$tmpjson" <<'PY'
 import json
@@ -108,10 +121,10 @@ walk(data, [])
 print("\n".join(hits))
 PY
 )
-  rm -f "$tmpjson"
   if [[ -n "$legacy" ]]; then
     echo "  FAIL: current pixiu IntegrationRequest does not bind top-level paramTypes:"
-    echo "$legacy" | sed 's/^/    - /'
+    formatted="    - ${legacy//$'\n'/$'\n    - '}"
+    printf '%s\n' "$formatted"
     echo "  (use mappingParams[].mapType for static args, or opt.types for dynamic generic routes)"
     errors=$((errors+1))
   else
@@ -124,6 +137,7 @@ fi
 section "4. mappingParams mapTo/mapType sanity"
 if has_yaml_reader && command -v python3 >/dev/null 2>&1; then
   tmpjson=$(mktemp -t pixiu-api-XXXXXX.json)
+  tmp_files+=("$tmpjson")
   yaml_to_json "$API_CFG" > "$tmpjson"
   map_errors=$(python3 - "$tmpjson" <<'PY'
 import json
@@ -159,12 +173,19 @@ allowed_opt = {
     "opt.method",
 }
 index_re = re.compile(r"^\d+$")
+http_target_re = re.compile(r"^(queryStrings|requestBody|headers|uri)(\.|$)")
 errors = []
 
-def check_mapping(mapping, trail):
+def check_mapping(mapping, trail, request_type):
     map_to = str(mapping.get("mapTo", ""))
-    if not (index_re.match(map_to) or map_to in allowed_opt):
-        errors.append(f"{trail}.mapTo={map_to!r} is not a numeric index or supported opt.* target")
+    if request_type == "dubbo":
+        if not (index_re.match(map_to) or map_to in allowed_opt):
+            errors.append(f"{trail}.mapTo={map_to!r} is not a numeric index or supported opt.* target")
+    elif request_type == "http":
+        if not http_target_re.match(map_to):
+            errors.append(f"{trail}.mapTo={map_to!r} is not a supported HTTP target path")
+    elif not (index_re.match(map_to) or map_to in allowed_opt or http_target_re.match(map_to)):
+        errors.append(f"{trail}.mapTo={map_to!r} is not a supported target")
     map_type = mapping.get("mapType")
     if map_type not in (None, "") and str(map_type) not in allowed_map_types:
         errors.append(f"{trail}.mapType={map_type!r} is not in current JTypeMapper")
@@ -173,9 +194,10 @@ def walk(node, trail):
     if isinstance(node, dict):
         mappings = node.get("mappingParams")
         if isinstance(mappings, list):
+            request_type = str(node.get("requestType", ""))
             for i, mapping in enumerate(mappings):
                 if isinstance(mapping, dict):
-                    check_mapping(mapping, ".".join(trail + ["mappingParams", str(i)]))
+                    check_mapping(mapping, ".".join(trail + ["mappingParams", str(i)]), request_type)
         for key, value in node.items():
             walk(value, trail + [str(key)])
     elif isinstance(node, list):
@@ -186,10 +208,10 @@ walk(data, [])
 print("\n".join(errors))
 PY
 )
-  rm -f "$tmpjson"
   if [[ -n "$map_errors" ]]; then
     echo "  FAIL:"
-    echo "$map_errors" | sed 's/^/    - /'
+    formatted="    - ${map_errors//$'\n'/$'\n    - '}"
+    printf '%s\n' "$formatted"
     errors=$((errors+1))
   else
     echo "  OK"
@@ -207,6 +229,7 @@ if [[ -n "$CONF_CFG" ]]; then
   else
     api_json=$(mktemp -t pixiu-api-XXXXXX.json)
     conf_json=$(mktemp -t pixiu-conf-XXXXXX.json)
+    tmp_files+=("$api_json" "$conf_json")
     yaml_to_json "$API_CFG" > "$api_json"
     yaml_to_json "$CONF_CFG" > "$conf_json"
     missing=$(python3 - "$api_json" "$conf_json" <<'PY'
@@ -238,7 +261,6 @@ declared = {str(c.get("name")) for c in clusters if isinstance(c, dict) and c.ge
 print(" ".join(sorted(refs - declared)))
 PY
 )
-    rm -f "$api_json" "$conf_json"
     if [[ -n "$missing" ]]; then
       echo "  FAIL: clusterName(s) referenced but not declared in conf.yaml:$missing"
       errors=$((errors+1))

--- a/skills/pixiu-llm-gateway/SKILL.md
+++ b/skills/pixiu-llm-gateway/SKILL.md
@@ -124,7 +124,7 @@ static_resources:
                     timeout: "60s"
   clusters:
     - name: "llm_cluster"
-      lb_policy: "lb"
+      lb_policy: "RoundRobin"
       endpoints:
         - id: "openai-primary"
           socket_address:
@@ -239,7 +239,7 @@ metadata keys such as `llm-meta.api_key`,
 Run:
 
 ```sh
-bash scripts/validate-llm-config.sh <conf.yaml>
+bash "$(git rev-parse --show-toplevel)/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh" <conf.yaml>
 ```
 
 The validator checks yaml syntax, filter order, required LLM cluster

--- a/skills/pixiu-llm-gateway/SKILL.md
+++ b/skills/pixiu-llm-gateway/SKILL.md
@@ -1,0 +1,296 @@
+---
+name: pixiu-llm-gateway
+description: |
+  Configure Apache dubbo-go-pixiu as an AI / LLM gateway. Use when the
+  user asks to proxy OpenAI-compatible, Claude-compatible, Gemini, vLLM,
+  DeepSeek, or self-hosted model endpoints; configure `dgp.filter.llm.proxy`,
+  `dgp.filter.llm.tokenizer`, `dgp.filter.ai.kvcache`, LLM retry/fallback,
+  endpoint `llm_meta`, token metrics, LMCache/vLLM cache-aware routing, or
+  Nacos LLM registry discovery. This skill is for Pixiu `conf.yaml`, not
+  `api_config.yaml`.
+allowed-tools: [Read, Grep, Glob, Edit, Write, Bash]
+metadata:
+  version: "0.1.1"
+  domain: ai-gateway
+  scope: generate-and-validate
+  triggers: ["LLM gateway", "AI gateway", "OpenAI proxy", "Claude proxy", "vLLM", "DeepSeek", "kvcache", "LMCache", "tokenizer", "token billing", "llm_meta", "dgp.filter.llm.proxy"]
+  pixiu_min_version: "0.6.0"
+  experimental: true
+  role: specialist
+---
+
+# pixiu-llm-gateway — Configuring Pixiu as an LLM Gateway
+
+Pixiu's LLM path is config-driven. The gateway routes normal HTTP
+requests to LLM-compatible upstreams through `dgp.filter.llm.proxy`,
+optionally records token metrics with `dgp.filter.llm.tokenizer`, and
+optionally hints cache-local routing with `dgp.filter.ai.kvcache`.
+
+This skill writes `conf.yaml` fragments. It does not write
+`api_config.yaml`; HTTP-to-Dubbo API mapping is a different code path.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- Expose an OpenAI-compatible chat/completions endpoint through Pixiu.
+- Route between multiple LLM providers or self-hosted vLLM instances.
+- Configure endpoint-level API keys, retry policy, fallback, or health
+  cooldown through `llm_meta`.
+- Enable token metrics / token accounting through
+  `dgp.filter.llm.tokenizer`.
+- Enable KV cache-aware routing through `dgp.filter.ai.kvcache`.
+- Discover LLM endpoints dynamically from Nacos via
+  `dgp.adapter.llmregistrycenter`.
+
+Do not use this skill for:
+
+- HTTP to Dubbo routes; use `pixiu-http-to-dubbo`.
+- MCP tool exposure; use `pixiu-mcp-integration`.
+- Authoring a new filter implementation; use `pixiu-filter-author`.
+
+## Step 0 — Verify Current Source First
+
+The LLM module is moving quickly. Before generating yaml, read the
+current repo shape:
+
+1. `pkg/common/constant/key.go` for the exact Kind strings.
+2. `pkg/filter/llm/proxy/filter.go` for proxy config, endpoint
+   selection, API key injection, retry, and fallback behavior.
+3. `pkg/filter/llm/tokenizer/tokenizer.go` for token metric behavior.
+4. `pkg/filter/ai/kvcache/config.go` and `handlers.go` for cache-aware
+   routing and the `endpoint.id` contract.
+5. `pkg/model/llm.go`, `pkg/model/cluster.go`, and `pkg/model/base.go`
+   for `llm_meta`, endpoint, and `socket_address` fields.
+6. `configs/ai_kvcache_config.yaml` and docs under `docs/ai/` if
+   present.
+
+If source disagrees with this skill, trust source and note the
+difference in the final answer.
+
+## Step 1 — Gather the Eight Things
+
+Do not produce a final config until these are explicit:
+
+1. HTTP listener address and route prefix/path, usually `/v1/`.
+2. Upstream mode: static `clusters[]` or Nacos LLM registry.
+3. Provider endpoints: host/domain, scheme (`http` or `https`), and
+   path convention (`/v1/chat/completions`, `/v1/completions`, etc.).
+4. API key handling: per-endpoint `llm_meta.api_key`, injected secret
+   placeholder, or caller-supplied Authorization header.
+5. Retry policy per endpoint: `NoRetry`, `CountBased`, or
+   `ExponentialBackoff`.
+6. Fallback behavior: whether endpoint failure should move to the next
+   endpoint in the same cluster.
+7. Token metrics: whether to add `dgp.filter.llm.tokenizer` and whether
+   console logging is acceptable.
+8. KV cache: whether vLLM `/tokenize` and LMCache controller endpoints
+   exist, and whether LMCache `instance_id` values match Pixiu
+   `endpoint.id`.
+
+It is fine to propose safe defaults, but make assumptions explicit.
+
+## Step 2 — Shape the Static Gateway Config
+
+Minimal static gateway shape:
+
+```yaml
+static_resources:
+  listeners:
+    - name: "net/http"
+      protocol_type: "HTTP"
+      address:
+        socket_address:
+          address: "0.0.0.0"
+          port: 8888
+      filter_chains:
+        filters:
+          - name: dgp.filter.httpconnectionmanager
+            config:
+              route_config:
+                routes:
+                  - match:
+                      prefix: "/v1/"
+                    route:
+                      cluster: "llm_cluster"
+                      cluster_not_found_response_code: 503
+              http_filters:
+                - name: dgp.filter.llm.tokenizer
+                  config:
+                    log_to_console: false
+                - name: dgp.filter.llm.proxy
+                  config:
+                    scheme: "https"
+                    timeout: "60s"
+  clusters:
+    - name: "llm_cluster"
+      lb_policy: "lb"
+      endpoints:
+        - id: "openai-primary"
+          socket_address:
+            domains:
+              - "api.openai.com"
+          llm_meta:
+            provider: "openai"
+            api_key: "${OPENAI_API_KEY}"
+            fallback: true
+            health_check_interval: 5000
+            retry_policy:
+              name: "ExponentialBackoff"
+              config:
+                times: 3
+                initialInterval: "200ms"
+                maxInterval: "5s"
+                multiplier: 2.0
+```
+
+Notes:
+
+- `dgp.filter.llm.proxy` forwards the original request path and query
+  to the selected endpoint. If the client calls `/v1/chat/completions`,
+  the upstream receives that same path.
+- `socket_address.domains[0]` should be a host, not a full URL and not
+  a path-bearing value. Current `llm.proxy` puts it into `url.URL.Host`;
+  use `api.openai.com`, not `https://api.openai.com` or
+  `api.openai.com/v1`.
+- `dgp.filter.llm.proxy.config.scheme` is filter-level. Every endpoint
+  reached by the same HTTP filter instance uses that one scheme, so do
+  not mix `https` providers and `http` local vLLM endpoints in the same
+  route/filter configuration. Split them by route/listener/cluster
+  arrangement or normalize the upstream scheme.
+- Endpoint API keys are injected as `Authorization: Bearer <api_key>`.
+  Do not hard-code production secrets; use placeholders or the user's
+  secret management convention.
+- `dgp.filter.llm.tokenizer` should be before `dgp.filter.llm.proxy` so
+  Decode starts timing before the upstream call. Its Encode phase reads
+  proxy attempt data and token usage from the response.
+
+## Step 3 — Add KV Cache Only When the Contract Exists
+
+KV cache-aware routing is optional. It only works when LMCache returns
+an `instance_id` that matches a Pixiu endpoint `id`.
+
+```yaml
+http_filters:
+  - name: dgp.filter.ai.kvcache
+    config:
+      enabled: true
+      vllm_endpoint: "http://127.0.0.1:8000"
+      lmcache_endpoint: "http://127.0.0.1:9000"
+      default_model: "Qwen2.5-3B-Instruct"
+      request_timeout: "2s"
+      lookup_routing_timeout: "50ms"
+      hot_window: "5m"
+      hot_max_records: 300
+      token_cache:
+        enabled: true
+        max_size: 1024
+        ttl: "10m"
+      cache_strategy:
+        enable_compression: true
+        enable_pinning: true
+        enable_eviction: true
+        load_threshold: 0.7
+        memory_threshold: 0.85
+        hot_content_threshold: 10
+        pin_instance_id: "vllm-instance-1"
+        pin_location: "LocalCPUBackend"
+        compress_instance_id: "vllm-instance-1"
+        compress_location: "LocalCPUBackend"
+        compress_method: "zstd"
+        evict_instance_id: "vllm-instance-1"
+  - name: dgp.filter.llm.tokenizer
+    config:
+      log_to_console: false
+  - name: dgp.filter.llm.proxy
+    config:
+      scheme: "http"
+      timeout: "60s"
+```
+
+Load `references/kvcache-config.md` before generating a kvcache config.
+
+## Step 4 — Use Nacos Discovery Only for Dynamic Endpoint Discovery
+
+Static clusters are simpler. Use `dgp.adapter.llmregistrycenter` only
+when LLM services register endpoint metadata into Nacos.
+
+```yaml
+adapters:
+  - id: "llm-nacos"
+    name: dgp.adapter.llmregistrycenter
+    config:
+      registries:
+        nacos:
+          protocol: nacos
+          address: "127.0.0.1:8848"
+          timeout: "5s"
+          group: "test_llm_registry_group"
+          namespace: "public"
+```
+
+The Nacos instance metadata must include `cluster`, `id`, and LLM
+metadata keys such as `llm-meta.api_key`,
+`llm-meta.retry_policy.name`, and `llm-meta.fallback`. Load
+`references/llm-registry.md` before generating Nacos instructions.
+
+## Step 5 — Validate
+
+Run:
+
+```sh
+bash scripts/validate-llm-config.sh <conf.yaml>
+```
+
+The validator checks yaml syntax, filter order, required LLM cluster
+fields, `llm_meta` placement, kvcache instance-id references, and
+Nacos adapter basics.
+
+## Cross-Cutting Rules
+
+### Always
+
+- Generate `conf.yaml` fragments, not `api_config.yaml`.
+- Use exact current Kind strings: `dgp.filter.llm.proxy`,
+  `dgp.filter.llm.tokenizer`, `dgp.filter.ai.kvcache`, and
+  `dgp.adapter.llmregistrycenter`.
+- Use singular `llm-meta.api_key` in Nacos metadata. Older docs may say
+  `llm-meta.api_keys`, but current source reads only the singular key.
+- Put `dgp.filter.ai.kvcache` and `dgp.filter.llm.tokenizer` before
+  `dgp.filter.llm.proxy` when enabled.
+- Keep `llm_meta` under each `clusters[].endpoints[]` entry.
+- Use endpoint `id` values that can be matched by kvcache / LMCache
+  instance IDs.
+- Use duration strings with units: `"60s"`, `"200ms"`, `"5m"`.
+
+### Never
+
+- Put LLM provider credentials in `api_config.yaml`.
+- Put `llm_meta` under the cluster instead of endpoints.
+- Put `scheme` under individual endpoints or put full URLs in
+  `socket_address.domains`. The proxy has one filter-level scheme and
+  endpoint domains must be host-only.
+- Use Nacos `llm-meta.api_keys` plural for current source.
+- Use old names such as `dgp.filter.http.llm.proxy` unless Step 0 proves
+  the target branch changed the Kind constants.
+- Enable kvcache without `vllm_endpoint`, `lmcache_endpoint`, and an
+  endpoint-id matching story.
+- Promise cost billing from config alone. Current tokenizer records
+  token metrics; pricing/currency math belongs outside the current
+  filter unless the target branch adds it.
+
+## References
+
+| File | When to load |
+|---|---|
+| [references/llm-endpoints.md](references/llm-endpoints.md) | Static LLM endpoint clusters, `llm_meta`, retry, fallback, API keys |
+| [references/kvcache-config.md](references/kvcache-config.md) | KV cache-aware routing, vLLM/LMCache fields, instance-id contract |
+| [references/tokenizer-metrics.md](references/tokenizer-metrics.md) | Tokenizer placement, metric names, streaming/unary response notes |
+| [references/llm-registry.md](references/llm-registry.md) | Nacos LLM registry adapter and instance metadata |
+| [references/troubleshooting.md](references/troubleshooting.md) | Common startup/runtime LLM gateway failures |
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/validate-llm-config.sh <conf.yaml>` | Static validation for LLM gateway `conf.yaml` fragments. |

--- a/skills/pixiu-llm-gateway/references/kvcache-config.md
+++ b/skills/pixiu-llm-gateway/references/kvcache-config.md
@@ -1,0 +1,82 @@
+# KV Cache-Aware Routing
+
+Current source anchors:
+
+- `pkg/filter/ai/kvcache/config.go`
+- `pkg/filter/ai/kvcache/filter.go`
+- `pkg/filter/ai/kvcache/handlers.go`
+- `docs/ai/kvcache.md`
+
+`dgp.filter.ai.kvcache` is a Decode filter. It parses the request
+body, records prompt hotness, optionally asks LMCache where a prompt is
+already cached, writes `llm_preferred_endpoint_id` into request context,
+and continues the chain. `dgp.filter.llm.proxy` then tries to route to
+that endpoint id.
+
+## Hard Contract
+
+LMCache lookup `instance_id` must match Pixiu `clusters[].endpoints[].id`.
+
+If LMCache returns `vllm-a`, then the LLM cluster must contain:
+
+```yaml
+endpoints:
+  - id: "vllm-a"
+    socket_address:
+      address: "127.0.0.1"
+      port: 8001
+```
+
+If no endpoint id matches, Pixiu falls back to normal load balancing.
+
+## Filter Order
+
+Use:
+
+```yaml
+http_filters:
+  - name: dgp.filter.ai.kvcache
+    config: ...
+  - name: dgp.filter.llm.tokenizer
+    config: ...
+  - name: dgp.filter.llm.proxy
+    config: ...
+```
+
+`kvcache` must run before proxy. `tokenizer` should also be before
+proxy so request timing begins before the upstream call.
+
+## Required Fields When Enabled
+
+```yaml
+enabled: true
+vllm_endpoint: "http://127.0.0.1:8000"
+lmcache_endpoint: "http://127.0.0.1:9000"
+default_model: "Qwen2.5-3B-Instruct"
+request_timeout: "2s"
+lookup_routing_timeout: "50ms"
+```
+
+When `enabled: true`, `vllm_endpoint` and `lmcache_endpoint` are
+required by current `Config.Validate()`.
+
+## Ratios and Non-Negative Values
+
+These must be in `[0,1]`:
+
+- `cache_strategy.memory_threshold`
+- `cache_strategy.load_threshold`
+
+These must be non-negative:
+
+- `token_cache.max_size`
+- `cache_strategy.hot_content_threshold`
+- `retry.max_attempts`
+- `hot_max_records`
+- `hot_max_keys`
+
+## Best-Effort Behavior
+
+KV cache management is best effort. Tokenize/lookup/pin/compress/evict
+failures are logged with `[kvcache]` and should not block the main LLM
+request path.

--- a/skills/pixiu-llm-gateway/references/llm-endpoints.md
+++ b/skills/pixiu-llm-gateway/references/llm-endpoints.md
@@ -1,0 +1,110 @@
+# LLM Endpoint and Proxy Configuration
+
+Current source anchors:
+
+- `pkg/common/constant/key.go`: exact Kind strings.
+- `pkg/filter/llm/proxy/filter.go`: proxy behavior.
+- `pkg/model/llm.go`: `llm_meta` fields.
+- `pkg/model/cluster.go`: endpoint layout.
+- `pkg/model/base.go`: `socket_address.domains` and `GetAddress()`.
+
+## Filter Kinds
+
+Use these current Kind strings:
+
+- `dgp.filter.llm.proxy`
+- `dgp.filter.llm.tokenizer`
+- `dgp.filter.ai.kvcache`
+
+Do not invent `dgp.filter.http.llm.*` names for current Pixiu.
+
+## Static Cluster Example
+
+```yaml
+route_config:
+  routes:
+    - match:
+        prefix: "/v1/"
+      route:
+        cluster: "llm_cluster"
+        cluster_not_found_response_code: 503
+http_filters:
+  - name: dgp.filter.llm.tokenizer
+    config:
+      log_to_console: false
+  - name: dgp.filter.llm.proxy
+    config:
+      scheme: "https"
+      timeout: "60s"
+
+clusters:
+  - name: "llm_cluster"
+    lb_policy: "lb"
+    endpoints:
+      - id: "openai-primary"
+        socket_address:
+          domains:
+            - "api.openai.com"
+        llm_meta:
+          provider: "openai"
+          api_key: "${OPENAI_API_KEY}"
+          fallback: true
+          health_check_interval: 5000
+          retry_policy:
+            name: "ExponentialBackoff"
+            config:
+              times: 3
+              initialInterval: "200ms"
+              maxInterval: "5s"
+              multiplier: 2.0
+```
+
+`dgp.filter.llm.proxy` reuses the inbound request path and query. If
+clients call `/v1/chat/completions`, the upstream sees
+`/v1/chat/completions`.
+
+Keep `socket_address.domains` host-only. Current proxy code puts
+`SocketAddress.GetAddress()` into `url.URL.Host`, so values such as
+`https://api.openai.com` or `api.openai.com/v1` are not safe static
+endpoint addresses.
+
+## Endpoint `llm_meta`
+
+`llm_meta` belongs under each endpoint, not under the cluster:
+
+| Field | Meaning |
+|---|---|
+| `provider` | Human/metadata label for logs and registry conversion |
+| `api_key` | Injected into upstream `Authorization: Bearer ...` |
+| `retry_policy.name` | `NoRetry`, `CountBased`, or `ExponentialBackoff` |
+| `retry_policy.config` | Policy-specific config map |
+| `fallback` | Whether to pick the next endpoint after failure |
+| `health_check_interval` | Millisecond cooldown before retrying unhealthy endpoint |
+
+## Retry Policies
+
+```yaml
+retry_policy:
+  name: "CountBased"
+  config:
+    times: 2
+```
+
+```yaml
+retry_policy:
+  name: "ExponentialBackoff"
+  config:
+    times: 3
+    initialInterval: "200ms"
+    maxInterval: "5s"
+    multiplier: 2.0
+```
+
+Use `NoRetry` or omit retry config for a single attempt.
+
+## API Key Handling
+
+The proxy replaces the upstream Authorization header when
+`llm_meta.api_key` is non-empty. For production examples, prefer
+placeholders such as `${OPENAI_API_KEY}` and document how the deployment
+system expands them. Do not paste real keys into generated configs.

--- a/skills/pixiu-llm-gateway/references/llm-endpoints.md
+++ b/skills/pixiu-llm-gateway/references/llm-endpoints.md
@@ -39,7 +39,7 @@ http_filters:
 
 clusters:
   - name: "llm_cluster"
-    lb_policy: "lb"
+    lb_policy: "RoundRobin"
     endpoints:
       - id: "openai-primary"
         socket_address:

--- a/skills/pixiu-llm-gateway/references/llm-registry.md
+++ b/skills/pixiu-llm-gateway/references/llm-registry.md
@@ -1,0 +1,60 @@
+# LLM Registry Discovery
+
+Current source anchors:
+
+- `pkg/adapter/llmregistry/registrycenter.go`
+- `pkg/adapter/llmregistry/registry/nacos/listener.go`
+- `docs/ai/registry.md`
+
+Use `dgp.adapter.llmregistrycenter` only when LLM services publish
+endpoint metadata into Nacos. Static `clusters[]` are simpler for one
+or two stable upstreams.
+
+## Adapter Config
+
+```yaml
+adapters:
+  - id: "llm-nacos"
+    name: dgp.adapter.llmregistrycenter
+    config:
+      registries:
+        nacos:
+          protocol: nacos
+          address: "127.0.0.1:8848"
+          timeout: "5s"
+          group: "test_llm_registry_group"
+          namespace: "public"
+```
+
+## Required Nacos Instance Metadata
+
+Each LLM instance should publish metadata such as:
+
+```json
+{
+  "cluster": "deepseek_cluster",
+  "id": "deepseek-primary",
+  "name": "DeepSeek primary",
+  "address": "api.deepseek.com",
+  "llm-meta.fallback": "true",
+  "llm-meta.api_key": "key-placeholder",
+  "llm-meta.retry_policy.name": "ExponentialBackoff",
+  "llm-meta.retry_policy.config": "{\"times\":3,\"initialInterval\":\"200ms\",\"maxInterval\":\"5s\",\"multiplier\":2.0}"
+}
+```
+
+Important details:
+
+- `cluster` groups endpoints into a Pixiu cluster.
+- `id` must be unique within the cluster.
+- `address` can override Nacos IP/port when the gateway should call a
+  public provider host.
+- Metadata keys use hyphenated `llm-meta.*`, not yaml `llm_meta`.
+- Current docs mention both `llm-meta.api_key` and older typo-like
+  `llm-meta.api_keys`; current source reads `llm-meta.api_key`.
+
+## Dynamic vs Static Config
+
+Even with registry discovery, the listener route and LLM filters still
+live in `conf.yaml`. Nacos supplies endpoints, not the entire HTTP
+listener.

--- a/skills/pixiu-llm-gateway/references/tokenizer-metrics.md
+++ b/skills/pixiu-llm-gateway/references/tokenizer-metrics.md
@@ -1,0 +1,56 @@
+# Tokenizer Metrics
+
+Current source anchor: `pkg/filter/llm/tokenizer/tokenizer.go`.
+
+`dgp.filter.llm.tokenizer` records token and upstream metrics. It adds
+both Decode and Encode filters: Decode captures the start time; Encode
+reads the response and proxy attempt metadata.
+
+## Config
+
+```yaml
+- name: dgp.filter.llm.tokenizer
+  config:
+    log_to_console: false
+```
+
+`log_to_console` is optional. Avoid enabling it in production examples
+unless the user explicitly wants verbose output.
+
+## Placement
+
+Place tokenizer before `dgp.filter.llm.proxy`:
+
+```yaml
+http_filters:
+  - name: dgp.filter.llm.tokenizer
+  - name: dgp.filter.llm.proxy
+```
+
+This lets Decode start timing before the proxy performs the upstream
+request. Encode later inspects unary and streaming responses.
+
+## Metrics Emitted
+
+Current metric names include:
+
+- `pixiu_llm_prompt_tokens_total`
+- `pixiu_llm_completion_tokens_total`
+- `pixiu_llm_total_tokens_total`
+- `pixiu_llm_upstream_requests_total`
+- `pixiu_llm_upstream_requests_success_total`
+- `pixiu_llm_upstream_requests_failure_total`
+- `pixiu_llm_total_duration_microseconds_sum_total`
+- `pixiu_llm_time_to_last_token_milliseconds_sum_total`
+- `pixiu_llm_streaming_requests_total`
+
+The tokenizer reads OpenAI-style `usage` fields for unary responses and
+SSE `data:` frames for streaming responses. If an upstream omits token
+usage, metrics may be partial.
+
+## Not Cost Billing by Itself
+
+The tokenizer measures tokens. It does not currently apply provider
+pricing, currency conversion, tenant billing accounts, or quota
+enforcement by itself. Do not promise cost billing unless the target
+branch has additional billing code.

--- a/skills/pixiu-llm-gateway/references/troubleshooting.md
+++ b/skills/pixiu-llm-gateway/references/troubleshooting.md
@@ -1,0 +1,44 @@
+# LLM Gateway Troubleshooting
+
+## 404 or route not matched
+
+- Check `route_config.routes[].match.prefix` or `path`.
+- Confirm the client path includes the upstream path you expect; proxy
+  forwards the inbound path.
+- Confirm `dgp.filter.httpconnectionmanager` owns the `http_filters`
+  list.
+
+## 503 cluster not found
+
+- `route.cluster` must match `static_resources.clusters[].name`.
+- With Nacos discovery, ensure the instance metadata has the same
+  `cluster` value.
+
+## Upstream 401
+
+- `llm_meta.api_key` may be missing or wrong.
+- If the caller should provide Authorization, leave endpoint
+  `api_key` empty; otherwise proxy overwrites Authorization with
+  `Bearer <api_key>`.
+- Never paste production keys into generated examples.
+
+## Fallback does not happen
+
+- `llm_meta.fallback` must be `true` on the failing endpoint.
+- There must be another endpoint in the same cluster.
+- Retry policy errors can skip an endpoint before a request is made.
+
+## Token metrics missing
+
+- Ensure `dgp.filter.llm.tokenizer` is in `http_filters`.
+- Put tokenizer before `dgp.filter.llm.proxy`.
+- Some upstreams omit OpenAI-style `usage` data; streaming metrics rely
+  on parseable SSE `data:` frames.
+
+## KV cache route hint ignored
+
+- LMCache returned an `instance_id` that does not equal any endpoint
+  `id`.
+- `dgp.filter.ai.kvcache` was placed after proxy.
+- `lookup_routing_timeout` is too low for the LMCache controller.
+- `enabled` is false or `vllm_endpoint` / `lmcache_endpoint` is empty.

--- a/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
+++ b/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# validate-llm-config.sh — structural validation for pixiu LLM gateway conf.yaml.
+#
+# Usage:
+#   validate-llm-config.sh <conf.yaml>
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <conf.yaml>" >&2
+  exit 1
+fi
+
+CONF="$1"
+if [[ ! -f "$CONF" ]]; then
+  echo "error: $CONF not found" >&2
+  exit 1
+fi
+
+yaml_to_json() {
+  local file="$1"
+  if command -v yq >/dev/null 2>&1; then
+    yq -o json eval '.' "$file"
+  elif command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+  else
+    return 127
+  fi
+}
+
+errors=0
+section() { echo; echo "== $* =="; }
+
+section "1. YAML syntax"
+tmpjson=$(mktemp -t pixiu-llm-XXXXXX.json)
+if yaml_to_json "$CONF" > "$tmpjson" 2>/tmp/pixiu-llm-yaml.err; then
+  echo "  OK"
+else
+  echo "  FAIL:"; cat /tmp/pixiu-llm-yaml.err
+  rm -f "$tmpjson"
+  exit 2
+fi
+
+section "2. LLM gateway semantics"
+semantic_errors=$(python3 - "$tmpjson" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    cfg = json.load(f) or {}
+
+errors = []
+sr = cfg.get("static_resources") or cfg
+listeners = sr.get("listeners") or []
+clusters = sr.get("clusters") or cfg.get("clusters") or []
+cluster_names = {c.get("name") for c in clusters if isinstance(c, dict)}
+endpoint_ids = {}
+for cluster in clusters:
+    if not isinstance(cluster, dict):
+        continue
+    cname = cluster.get("name")
+    endpoint_ids[cname] = set()
+    for ep in cluster.get("endpoints") or []:
+        if not isinstance(ep, dict):
+            continue
+        if ep.get("id"):
+            endpoint_ids[cname].add(str(ep.get("id")))
+        domains = ((ep.get("socket_address") or {}).get("domains") or [])
+        for domain in domains:
+            if "://" in str(domain) or "/" in str(domain):
+                errors.append(f"cluster {cname}: endpoint {ep.get('id')} socket_address.domains entries must be host-only, got {domain!r}")
+        meta = ep.get("llm_meta")
+        if meta is not None and not isinstance(meta, dict):
+            errors.append(f"cluster {cname}: endpoint {ep.get('id')} llm_meta must be a map")
+        if isinstance(meta, dict):
+            rp = meta.get("retry_policy")
+            if rp and not isinstance(rp, dict):
+                errors.append(f"cluster {cname}: endpoint {ep.get('id')} retry_policy must be a map")
+
+all_http_filters = []
+routes = []
+for listener in listeners:
+    for chain in (((listener or {}).get("filter_chains") or {}).get("filters") or []):
+        if not isinstance(chain, dict):
+            continue
+        if chain.get("name") != "dgp.filter.httpconnectionmanager":
+            continue
+        hcm = chain.get("config") or {}
+        routes.extend(((hcm.get("route_config") or {}).get("routes") or []))
+        all_http_filters.extend(hcm.get("http_filters") or [])
+
+filter_names = [f.get("name") for f in all_http_filters if isinstance(f, dict)]
+if "dgp.filter.llm.proxy" not in filter_names:
+    errors.append("missing dgp.filter.llm.proxy in http_filters")
+else:
+    proxy_i = filter_names.index("dgp.filter.llm.proxy")
+    for before in ("dgp.filter.ai.kvcache", "dgp.filter.llm.tokenizer"):
+        if before in filter_names and filter_names.index(before) > proxy_i:
+            errors.append(f"{before} must be before dgp.filter.llm.proxy")
+
+for route in routes:
+    cluster = ((route or {}).get("route") or {}).get("cluster")
+    if cluster and cluster not in cluster_names:
+        errors.append(f"route references missing cluster {cluster!r}")
+
+for f in all_http_filters:
+    if not isinstance(f, dict) or f.get("name") != "dgp.filter.ai.kvcache":
+        continue
+    c = f.get("config") or {}
+    if c.get("enabled") is True:
+        if not c.get("vllm_endpoint"):
+            errors.append("kvcache enabled but vllm_endpoint is empty")
+        if not c.get("lmcache_endpoint"):
+            errors.append("kvcache enabled but lmcache_endpoint is empty")
+    cs = c.get("cache_strategy") or {}
+    for key in ("pin_instance_id", "compress_instance_id", "evict_instance_id"):
+        val = cs.get(key)
+        if val and not any(val in ids for ids in endpoint_ids.values()):
+            errors.append(f"kvcache {key}={val!r} does not match any endpoint id")
+    for key in ("memory_threshold", "load_threshold"):
+        val = cs.get(key)
+        if val is not None:
+            try:
+                n = float(val)
+                if n < 0 or n > 1:
+                    errors.append(f"cache_strategy.{key} must be between 0 and 1")
+            except Exception:
+                errors.append(f"cache_strategy.{key} must be numeric")
+
+adapters = cfg.get("adapters") or sr.get("adapters") or []
+for adapter in adapters:
+    if not isinstance(adapter, dict) or adapter.get("name") != "dgp.adapter.llmregistrycenter":
+        continue
+    regs = ((adapter.get("config") or {}).get("registries") or {})
+    if not regs:
+        errors.append("llmregistrycenter adapter has no registries")
+    for name, reg in regs.items():
+        if (reg or {}).get("protocol") != "nacos":
+            errors.append(f"llm registry {name} protocol should be nacos for current source")
+        if not (reg or {}).get("address"):
+            errors.append(f"llm registry {name} address is empty")
+
+print("\n".join(errors))
+PY
+)
+rm -f "$tmpjson"
+
+if [[ -n "$semantic_errors" ]]; then
+  echo "  FAIL:"
+  echo "$semantic_errors" | sed 's/^/    - /'
+  errors=$((errors+1))
+else
+  echo "  OK"
+fi
+
+echo
+if [[ $errors -eq 0 ]]; then
+  echo "Validation passed."
+  exit 0
+else
+  echo "Validation failed with $errors error group(s)."
+  exit 2
+fi

--- a/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
+++ b/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
@@ -23,27 +23,49 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
   else
     return 127
   fi
 }
 
+has_yaml_reader() {
+  command -v yq >/dev/null 2>&1 || command -v ruby >/dev/null 2>&1
+}
+
 errors=0
+tmp_files=()
+
+cleanup() {
+  if [[ ${#tmp_files[@]} -gt 0 ]]; then
+    rm -f "${tmp_files[@]}"
+  fi
+}
+trap cleanup EXIT
+
 section() { echo; echo "== $* =="; }
 
 section "1. YAML syntax"
 tmpjson=$(mktemp -t pixiu-llm-XXXXXX.json)
-if yaml_to_json "$CONF" > "$tmpjson" 2>/tmp/pixiu-llm-yaml.err; then
+tmp_files+=("$tmpjson")
+yaml_err=$(mktemp -t pixiu-llm-yaml-XXXXXX)
+tmp_files+=("$yaml_err")
+if ! has_yaml_reader; then
+  echo "  SKIP (install yq or ruby for YAML parsing)"
+elif yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
   echo "  OK"
 else
-  echo "  FAIL:"; cat /tmp/pixiu-llm-yaml.err
-  rm -f "$tmpjson"
+  echo "  FAIL:"; cat "$yaml_err"
   exit 2
 fi
 
 section "2. LLM gateway semantics"
-semantic_errors=$(python3 - "$tmpjson" <<'PY'
+if ! has_yaml_reader; then
+  echo "  SKIP (install yq or ruby for YAML parsing)"
+elif ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP (install python3 for semantic validation)"
+else
+  semantic_errors=$(python3 - "$tmpjson" <<'PY'
 import json
 import sys
 
@@ -51,6 +73,7 @@ with open(sys.argv[1], "r", encoding="utf-8") as f:
     cfg = json.load(f) or {}
 
 errors = []
+warnings = []
 sr = cfg.get("static_resources") or cfg
 listeners = sr.get("listeners") or []
 clusters = sr.get("clusters") or cfg.get("clusters") or []
@@ -80,8 +103,24 @@ for cluster in clusters:
 
 all_http_filters = []
 routes = []
+
+def network_filters(listener):
+    if not isinstance(listener, dict):
+        return []
+    filter_chains = listener.get("filter_chains") or []
+    if isinstance(filter_chains, dict):
+        filter_chains = [filter_chains]
+    elif not isinstance(filter_chains, list):
+        return []
+
+    filters = []
+    for fc in filter_chains:
+        if isinstance(fc, dict):
+            filters.extend(fc.get("filters") or [])
+    return filters
+
 for listener in listeners:
-    for chain in (((listener or {}).get("filter_chains") or {}).get("filters") or []):
+    for chain in network_filters(listener):
         if not isinstance(chain, dict):
             continue
         if chain.get("name") != "dgp.filter.httpconnectionmanager":
@@ -136,22 +175,26 @@ for adapter in adapters:
     if not regs:
         errors.append("llmregistrycenter adapter has no registries")
     for name, reg in regs.items():
-        if (reg or {}).get("protocol") != "nacos":
-            errors.append(f"llm registry {name} protocol should be nacos for current source")
+        protocol = (reg or {}).get("protocol")
+        if protocol != "nacos":
+            warnings.append(f"llm registry {name} protocol is {protocol!r}; current examples use nacos")
         if not (reg or {}).get("address"):
             errors.append(f"llm registry {name} address is empty")
 
+for warning in warnings:
+    print(f"WARN: {warning}", file=sys.stderr)
 print("\n".join(errors))
 PY
 )
-rm -f "$tmpjson"
 
-if [[ -n "$semantic_errors" ]]; then
-  echo "  FAIL:"
-  echo "$semantic_errors" | sed 's/^/    - /'
-  errors=$((errors+1))
-else
-  echo "  OK"
+  if [[ -n "$semantic_errors" ]]; then
+    echo "  FAIL:"
+    formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
+    printf '%s\n' "$formatted"
+    errors=$((errors+1))
+  else
+    echo "  OK"
+  fi
 fi
 
 echo

--- a/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
+++ b/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
@@ -45,14 +45,26 @@ trap cleanup EXIT
 
 section() { echo; echo "== $* =="; }
 
+if ! has_yaml_reader; then
+  echo "error: install yq (preferred) or ruby for YAML parsing." >&2
+  echo "       macOS: brew install yq" >&2
+  echo "       Debian/Ubuntu: apt install yq" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required for LLM semantic validation." >&2
+  echo "       macOS: brew install python" >&2
+  echo "       Debian/Ubuntu: apt install python3" >&2
+  exit 1
+fi
+
 section "1. YAML syntax"
 tmpjson=$(mktemp -t pixiu-llm-XXXXXX.json)
 tmp_files+=("$tmpjson")
 yaml_err=$(mktemp -t pixiu-llm-yaml-XXXXXX)
 tmp_files+=("$yaml_err")
-if ! has_yaml_reader; then
-  echo "  SKIP (install yq or ruby for YAML parsing)"
-elif yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
+if yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
   echo "  OK"
 else
   echo "  FAIL:"; cat "$yaml_err"
@@ -60,12 +72,7 @@ else
 fi
 
 section "2. LLM gateway semantics"
-if ! has_yaml_reader; then
-  echo "  SKIP (install yq or ruby for YAML parsing)"
-elif ! command -v python3 >/dev/null 2>&1; then
-  echo "  SKIP (install python3 for semantic validation)"
-else
-  semantic_errors=$(python3 - "$tmpjson" <<'PY'
+semantic_errors=$(python3 - "$tmpjson" <<'PY'
 import json
 import sys
 
@@ -239,14 +246,13 @@ print("\n".join(errors))
 PY
 )
 
-  if [[ -n "$semantic_errors" ]]; then
-    echo "  FAIL:"
-    formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
-    printf '%s\n' "$formatted"
-    errors=$((errors+1))
-  else
-    echo "  OK"
-  fi
+if [[ -n "$semantic_errors" ]]; then
+  echo "  FAIL:"
+  formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
+  printf '%s\n' "$formatted"
+  errors=$((errors+1))
+else
+  echo "  OK"
 fi
 
 echo

--- a/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
+++ b/skills/pixiu-llm-gateway/scripts/validate-llm-config.sh
@@ -23,7 +23,7 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
+    ruby -ryaml -rjson -e 'begin; puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false)); rescue StandardError => e; warn "#{e.class}: #{e.message}"; exit 1; end' "$file"
   else
     return 127
   fi
@@ -70,26 +70,65 @@ import json
 import sys
 
 with open(sys.argv[1], "r", encoding="utf-8") as f:
-    cfg = json.load(f) or {}
+    raw_cfg = json.load(f)
 
 errors = []
 warnings = []
-sr = cfg.get("static_resources") or cfg
-listeners = sr.get("listeners") or []
-clusters = sr.get("clusters") or cfg.get("clusters") or []
-cluster_names = {c.get("name") for c in clusters if isinstance(c, dict)}
+
+def dict_field(container, key, label):
+    if not isinstance(container, dict):
+        return {}
+    value = container.get(key)
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{label} must be a map/object")
+    return {}
+
+def list_field(container, key, label):
+    if not isinstance(container, dict):
+        return []
+    value = container.get(key)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    errors.append(f"{label} must be a list")
+    return []
+
+if not isinstance(raw_cfg, dict):
+    errors.append("top-level config must be a map/object")
+    cfg = {}
+else:
+    cfg = raw_cfg
+
+sr_value = cfg.get("static_resources")
+if sr_value is None:
+    sr = cfg
+elif isinstance(sr_value, dict):
+    sr = sr_value
+else:
+    errors.append("static_resources must be a map/object")
+    sr = {}
+
+listeners = list_field(sr, "listeners", "static_resources.listeners")
+clusters = list_field(sr, "clusters", "static_resources.clusters")
+if not clusters and sr is not cfg:
+    clusters = list_field(cfg, "clusters", "clusters")
+cluster_names = {c.get("name") for c in clusters if isinstance(c, dict) and c.get("name")}
 endpoint_ids = {}
 for cluster in clusters:
     if not isinstance(cluster, dict):
         continue
     cname = cluster.get("name")
     endpoint_ids[cname] = set()
-    for ep in cluster.get("endpoints") or []:
+    for ep in list_field(cluster, "endpoints", f"cluster {cname}.endpoints"):
         if not isinstance(ep, dict):
             continue
         if ep.get("id"):
             endpoint_ids[cname].add(str(ep.get("id")))
-        domains = ((ep.get("socket_address") or {}).get("domains") or [])
+        domains = list_field(dict_field(ep, "socket_address", f"cluster {cname} endpoint socket_address"), "domains", f"cluster {cname} endpoint socket_address.domains")
         for domain in domains:
             if "://" in str(domain) or "/" in str(domain):
                 errors.append(f"cluster {cname}: endpoint {ep.get('id')} socket_address.domains entries must be host-only, got {domain!r}")
@@ -125,9 +164,9 @@ for listener in listeners:
             continue
         if chain.get("name") != "dgp.filter.httpconnectionmanager":
             continue
-        hcm = chain.get("config") or {}
-        routes.extend(((hcm.get("route_config") or {}).get("routes") or []))
-        all_http_filters.extend(hcm.get("http_filters") or [])
+        hcm = dict_field(chain, "config", "dgp.filter.httpconnectionmanager.config")
+        routes.extend(list_field(dict_field(hcm, "route_config", "route_config"), "routes", "route_config.routes"))
+        all_http_filters.extend(list_field(hcm, "http_filters", "http_filters"))
 
 filter_names = [f.get("name") for f in all_http_filters if isinstance(f, dict)]
 if "dgp.filter.llm.proxy" not in filter_names:
@@ -139,20 +178,20 @@ else:
             errors.append(f"{before} must be before dgp.filter.llm.proxy")
 
 for route in routes:
-    cluster = ((route or {}).get("route") or {}).get("cluster")
+    cluster = dict_field(route, "route", "route.route").get("cluster")
     if cluster and cluster not in cluster_names:
         errors.append(f"route references missing cluster {cluster!r}")
 
 for f in all_http_filters:
     if not isinstance(f, dict) or f.get("name") != "dgp.filter.ai.kvcache":
         continue
-    c = f.get("config") or {}
+    c = dict_field(f, "config", "dgp.filter.ai.kvcache.config")
     if c.get("enabled") is True:
         if not c.get("vllm_endpoint"):
             errors.append("kvcache enabled but vllm_endpoint is empty")
         if not c.get("lmcache_endpoint"):
             errors.append("kvcache enabled but lmcache_endpoint is empty")
-    cs = c.get("cache_strategy") or {}
+    cs = dict_field(c, "cache_strategy", "cache_strategy")
     for key in ("pin_instance_id", "compress_instance_id", "evict_instance_id"):
         val = cs.get(key)
         if val and not any(val in ids for ids in endpoint_ids.values()):
@@ -167,18 +206,31 @@ for f in all_http_filters:
             except Exception:
                 errors.append(f"cache_strategy.{key} must be numeric")
 
-adapters = cfg.get("adapters") or sr.get("adapters") or []
+if cfg.get("adapters") is not None:
+    adapters = list_field(cfg, "adapters", "adapters")
+else:
+    adapters = list_field(sr, "adapters", "static_resources.adapters")
 for adapter in adapters:
     if not isinstance(adapter, dict) or adapter.get("name") != "dgp.adapter.llmregistrycenter":
         continue
-    regs = ((adapter.get("config") or {}).get("registries") or {})
-    if not regs:
+    adapter_config = dict_field(adapter, "config", "llmregistrycenter config")
+    regs_value = adapter_config.get("registries")
+    if regs_value is None:
         errors.append("llmregistrycenter adapter has no registries")
-    for name, reg in regs.items():
-        protocol = (reg or {}).get("protocol")
+        continue
+    if not isinstance(regs_value, dict):
+        errors.append("llmregistrycenter adapter registries must be a map/object")
+        continue
+    if not regs_value:
+        errors.append("llmregistrycenter adapter has no registries")
+    for name, reg in regs_value.items():
+        if not isinstance(reg, dict):
+            errors.append(f"llm registry {name} must be a map/object")
+            continue
+        protocol = reg.get("protocol")
         if protocol != "nacos":
             warnings.append(f"llm registry {name} protocol is {protocol!r}; current examples use nacos")
-        if not (reg or {}).get("address"):
+        if not reg.get("address"):
             errors.append(f"llm registry {name} address is empty")
 
 for warning in warnings:

--- a/skills/pixiu-mcp-integration/SKILL.md
+++ b/skills/pixiu-mcp-integration/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: pixiu-mcp-integration
+description: |
+  Use when configuring dubbo-go-pixiu as an MCP gateway:
+  `dgp.filter.mcp.mcpserver`, Streamable HTTP/SSE, `tools/list`,
+  `tools/call`, OAuth/JWT `dgp.filter.http.auth.mcp`, Nacos
+  `dgp.adapter.mcpserver`, or stdio MCP bridge guidance.
+allowed-tools: [Read, Grep, Glob, Edit, Write, Bash]
+metadata:
+  version: "0.1.1"
+  domain: ai-gateway
+  scope: generate-and-validate
+  triggers: ["MCP", "Model Context Protocol", "mcpserver", "tools/list", "tools/call", "Mcp-Session-Id", "dgp.filter.mcp.mcpserver", "dgp.filter.http.auth.mcp", "mcp gateway", "MCP tool"]
+  pixiu_min_version: "0.6.0"
+  experimental: true
+  role: specialist
+---
+
+# pixiu-mcp-integration — Exposing HTTP APIs as MCP Tools
+
+Pixiu's current MCP integration is an HTTP filter that speaks MCP
+Streamable HTTP/SSE to clients and maps `tools/call` to backend HTTP
+clusters. It can also expose resources, resource templates, prompts,
+and optional OAuth/JWT protection.
+
+Important boundary: current Pixiu does not directly spawn or manage
+stdio MCP servers. For a stdio server, put an external bridge in front
+of it, then configure Pixiu to call the bridge as an HTTP backend tool.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- Expose existing backend HTTP APIs as MCP tools.
+- Configure MCP endpoint metadata, tools, resources, templates, or
+  prompts.
+- Support Streamable HTTP / SSE MCP clients.
+- Protect the MCP endpoint with OAuth 2.0 protected-resource metadata
+  and JWT validation.
+- Load MCP tool definitions dynamically from Nacos.
+- Integrate stdio MCP servers by documenting the required bridge.
+
+Do not use this skill for:
+
+- LLM model proxying; use `pixiu-llm-gateway`.
+- HTTP to Dubbo API mapping; use `pixiu-http-to-dubbo`.
+- Writing a new filter implementation; use `pixiu-filter-author`.
+
+## Step 0 — Verify Current Source First
+
+Read current source before generating config:
+
+1. `pkg/common/constant/key.go` for Kind strings.
+2. `pkg/model/mcpserver.go` for `McpServerConfig`, tool args,
+   resources, templates, and prompts.
+3. `pkg/filter/mcp/mcpserver/plugin.go`, `filter.go`, `handlers.go`,
+   and `transport/` for endpoint matching, Streamable HTTP/SSE, and
+   JSON-RPC handling.
+4. `pkg/filter/auth/mcp/config.go` and `filter.go` for optional auth.
+5. `pkg/adapter/mcpserver/registrycenter.go` and
+   `pkg/adapter/mcpserver/registry/nacos/` for dynamic tool discovery.
+6. `docs/ai/mcp/mcp.md` if present.
+
+If current source disagrees with this skill, trust the source and note
+the difference.
+
+## Step 1 — Gather the Nine Things
+
+Do not generate final config until these are explicit:
+
+1. MCP endpoint path, usually `/mcp`.
+2. Server name, version, description, and instructions.
+3. Static tools or Nacos-managed tools.
+4. For every static tool: name, description, upstream cluster,
+   request method/path/timeout, and argument schema.
+5. Backend clusters for each tool.
+6. Whether resources, resource templates, or prompts should be exposed.
+7. Transport expectation: JSON POST only, SSE GET stream, or both.
+8. Auth requirement: none, or `dgp.filter.http.auth.mcp` with issuer,
+   JWKS URL, resource URI, and protected cluster.
+9. If the user says stdio MCP: which external bridge will expose it as
+   HTTP/SSE. Pixiu itself does not run the stdio process.
+
+## Step 2 — Shape the Static MCP Server Config
+
+Load `references/mcp-server-config.md` before generating a static tool
+config. Keep the generated config compact but include these essentials:
+
+- `endpoint` must match the client URL path. Current filter checks
+  `ctx.Request.URL.Path == cfg.Endpoint`.
+- The `mcp-backend` route cluster is a routing anchor for the MCP
+  endpoint. Each tool has its own `cluster` for the actual backend call.
+- Declare every static tool cluster under `static_resources.clusters[]`.
+- Put `dgp.filter.mcp.mcpserver` before `dgp.filter.http.httpproxy`.
+- `tools/list`, `resources/list`, `prompts/list`, `initialize`,
+  `ping`, and `notifications/initialized` are terminal methods handled
+  by the MCP filter.
+- `tools/call` continues through the chain to an HTTP proxy, then
+  Encode converts the backend response into MCP tool-call output.
+- Current source declares `request.headers`, but `buildBackendRequest`
+  does not apply them yet. Do not rely on static tool headers for
+  runtime behavior; request bodies still get `Content-Type:
+  application/json` automatically.
+
+## Step 3 — Add OAuth/JWT Protection When Required
+
+Place `dgp.filter.http.auth.mcp` before `dgp.filter.mcp.mcpserver`:
+
+```yaml
+http_filters:
+  - name: dgp.filter.http.auth.mcp
+    config:
+      resource_metadata:
+        path: "/.well-known/oauth-protected-resource/mcp"
+        resource: "https://mcp.example.com/mcp"
+        authorization_servers:
+          - "https://auth.example.com"
+      providers:
+        - name: "main"
+          issuer: "https://auth.example.com"
+          jwks: "https://auth.example.com/.well-known/jwks.json"
+          audience: "https://mcp.example.com/mcp"
+      rules:
+        - cluster: "mcp-backend"
+  - name: dgp.filter.mcp.mcpserver
+    config: ...
+```
+
+Auth rules match the route entry's cluster. If `rules[].cluster` does
+not match the MCP route cluster, requests will not be protected.
+On successful validation the current auth filter removes the
+`Authorization` header before forwarding. Do not promise that the
+caller token reaches the tool backend; if the backend needs credentials,
+design an explicit downstream auth strategy instead of relying on the
+validated bearer token being forwarded.
+
+Load `references/mcp-auth.md` before generating auth config.
+
+## Step 4 — Use Nacos Only for Dynamic Tool Definitions
+
+Static tools are easier. Use `dgp.adapter.mcpserver` only when a Nacos
+MCP registry supplies tool definitions.
+
+```yaml
+adapters:
+  - id: "mcp-nacos-adapter"
+    name: dgp.adapter.mcpserver
+    config:
+      registries:
+        nacos:
+          protocol: "nacos"
+          address: "127.0.0.1:8848"
+          timeout: "5s"
+          username: "nacos"
+          password: "nacos"
+          namespace: ""
+          group: "DEFAULT_GROUP"
+```
+
+The listener still needs `dgp.filter.mcp.mcpserver`; the adapter updates
+the in-process tool registry and may register endpoints for tools with
+`backend_url`.
+
+Load `references/mcp-registry.md` before generating Nacos instructions.
+
+## Step 5 — Validate and Smoke Test
+
+Run:
+
+```sh
+bash scripts/validate-mcp-config.sh <conf.yaml>
+```
+
+Smoke-test Streamable HTTP:
+
+```sh
+curl -i -X POST http://localhost:8888/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"curl","version":"1.0.0"}}}'
+```
+
+For SSE, the client should call `GET /mcp` with
+`Accept: text/event-stream` and then reuse the returned
+`Mcp-Session-Id` on POST requests.
+
+## Cross-Cutting Rules
+
+### Always
+
+- Use exact current Kinds: `dgp.filter.mcp.mcpserver`,
+  `dgp.filter.http.auth.mcp`, and `dgp.adapter.mcpserver`.
+- Put auth before MCP server when auth is enabled.
+- Keep `endpoint` and route prefix/path aligned.
+- Ensure every tool `cluster` exists in `static_resources.clusters[]`
+  unless it is dynamically supplied by the adapter.
+- Use arg `in` values `path`, `query`, or `body`.
+- Use arg `type` values `string`, `integer`, `number`, or `boolean`.
+
+### Never
+
+- Claim Pixiu can directly run a stdio MCP server. It needs an external
+  HTTP/SSE bridge for stdio-based servers.
+- Put `tools` at top level; they belong under the MCP filter config.
+- Put `dgp.filter.mcp.mcpserver` after `httpproxy`; terminal MCP
+  methods must be handled before proxying.
+- Forget `dgp.filter.http.httpproxy` when `tools/call` needs to reach a
+  backend HTTP service.
+- Configure auth `rules[].cluster` with the tool backend cluster when
+  the MCP route itself uses a different route cluster.
+- Rely on `request.headers` for static tool backend credentials in the
+  current source. The model field exists, but `buildBackendRequest` does
+  not apply it yet; use an external bridge/proxy, backend-side auth, or
+  a source change before promising static header injection.
+
+## References
+
+| File | When to load |
+|---|---|
+| [references/mcp-server-config.md](references/mcp-server-config.md) | Static server_info, tools, args, resources, templates, prompts |
+| [references/mcp-transport.md](references/mcp-transport.md) | Streamable HTTP/SSE behavior, required headers, smoke tests |
+| [references/mcp-auth.md](references/mcp-auth.md) | OAuth protected resource metadata and JWT provider/rule config |
+| [references/mcp-registry.md](references/mcp-registry.md) | Nacos MCP adapter and dynamic tool loading |
+| [references/troubleshooting.md](references/troubleshooting.md) | Common startup/runtime MCP failures |
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/validate-mcp-config.sh <conf.yaml>` | Static validation for MCP gateway `conf.yaml` fragments. |

--- a/skills/pixiu-mcp-integration/SKILL.md
+++ b/skills/pixiu-mcp-integration/SKILL.md
@@ -168,7 +168,7 @@ Load `references/mcp-registry.md` before generating Nacos instructions.
 Run:
 
 ```sh
-bash scripts/validate-mcp-config.sh <conf.yaml>
+bash "$(git rev-parse --show-toplevel)/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh" <conf.yaml>
 ```
 
 Smoke-test Streamable HTTP:

--- a/skills/pixiu-mcp-integration/references/mcp-auth.md
+++ b/skills/pixiu-mcp-integration/references/mcp-auth.md
@@ -1,0 +1,68 @@
+# MCP Auth Filter
+
+Current source anchors:
+
+- `pkg/filter/auth/mcp/config.go`
+- `pkg/filter/auth/mcp/filter.go`
+- `pkg/filter/auth/mcp/internal/validator/`
+
+Use `dgp.filter.http.auth.mcp` when the MCP endpoint must be protected
+by OAuth 2.0 protected-resource metadata and JWT validation.
+
+## Filter Order
+
+```yaml
+http_filters:
+  - name: dgp.filter.http.auth.mcp
+    config: ...
+  - name: dgp.filter.mcp.mcpserver
+    config: ...
+  - name: dgp.filter.http.httpproxy
+```
+
+Auth must run before the MCP server filter.
+
+## Config
+
+```yaml
+resource_metadata:
+  path: "/.well-known/oauth-protected-resource/mcp"
+  resource: "https://mcp.example.com/mcp"
+  authorization_servers:
+    - "https://auth.example.com"
+providers:
+  - name: "main"
+    issuer: "https://auth.example.com"
+    jwks: "https://auth.example.com/.well-known/jwks.json"
+    audience: "https://mcp.example.com/mcp"
+rules:
+  - cluster: "mcp-backend"
+```
+
+Required:
+
+- `resource_metadata.resource`
+- `resource_metadata.authorization_servers`
+- at least one provider
+- each provider `name`, `issuer`, and `jwks`
+
+If provider `audience` is omitted, current code defaults it to
+`resource_metadata.resource`.
+
+## Rules Match Route Cluster
+
+Rules are matched against the route entry's cluster, not the tool's
+backend cluster. If route config sends `/mcp` to `mcp-backend`, then
+auth should use:
+
+```yaml
+rules:
+  - cluster: "mcp-backend"
+```
+
+## Runtime Behavior
+
+- The metadata path returns the OAuth protected-resource metadata JSON.
+- Missing/invalid bearer tokens return `401` with `WWW-Authenticate`.
+- On success, the Authorization header is removed before forwarding to
+  downstream services to avoid token leakage.

--- a/skills/pixiu-mcp-integration/references/mcp-registry.md
+++ b/skills/pixiu-mcp-integration/references/mcp-registry.md
@@ -1,0 +1,54 @@
+# MCP Nacos Registry Integration
+
+Current source anchors:
+
+- `pkg/adapter/mcpserver/registrycenter.go`
+- `pkg/adapter/mcpserver/registry/nacos/`
+- `docs/ai/mcp/mcp.md`
+
+Use `dgp.adapter.mcpserver` when MCP tool definitions are managed by
+Nacos. The listener still needs `dgp.filter.mcp.mcpserver`; the adapter
+updates the in-process tool registry.
+
+## Adapter Config
+
+```yaml
+adapters:
+  - id: "mcp-nacos-adapter"
+    name: dgp.adapter.mcpserver
+    config:
+      registries:
+        nacos:
+          protocol: "nacos"
+          address: "127.0.0.1:8848"
+          timeout: "5s"
+          username: "nacos"
+          password: "nacos"
+          namespace: ""
+          group: "DEFAULT_GROUP"
+```
+
+Current adapter code only handles `protocol: nacos`; other registry
+protocols are skipped.
+
+## Dynamic Tool Effects
+
+When Nacos config changes:
+
+- The adapter applies `McpServerConfig` into the global MCP dynamic
+  registry.
+- For tools with `backend_url`, it parses host/port and registers an
+  endpoint in the cluster named by `tool.cluster`.
+
+## Static Plus Dynamic
+
+It is valid to configure `server_info` statically and load tools
+dynamically. Keep a minimal `dgp.filter.mcp.mcpserver` config in
+`http_filters` even when all tools come from Nacos.
+
+## Nacos Operational Notes
+
+- Use `namespace` for environment isolation.
+- Use `group` for service grouping.
+- Ensure generated `backend_url` values are valid URLs with host and
+  port; malformed URLs are logged and skipped by the adapter.

--- a/skills/pixiu-mcp-integration/references/mcp-server-config.md
+++ b/skills/pixiu-mcp-integration/references/mcp-server-config.md
@@ -1,0 +1,128 @@
+# MCP Server Filter Configuration
+
+Current source anchors:
+
+- `pkg/model/mcpserver.go`
+- `pkg/filter/mcp/mcpserver/plugin.go`
+- `pkg/filter/mcp/mcpserver/filter.go`
+- `pkg/filter/mcp/mcpserver/handlers.go`
+
+## Kind and Endpoint
+
+Use current Kind:
+
+```yaml
+- name: dgp.filter.mcp.mcpserver
+  config:
+    endpoint: "/mcp"
+```
+
+Current filter matches MCP requests by exact path:
+`ctx.Request.URL.Path == cfg.Endpoint`.
+
+## Server Info
+
+```yaml
+server_info:
+  name: "Pixiu MCP Gateway"
+  version: "1.0.0"
+  description: "Expose backend APIs as MCP tools"
+  instructions: "Use tools/list then tools/call."
+```
+
+## Tools
+
+Each tool maps an MCP `tools/call` to a backend HTTP request.
+
+```yaml
+tools:
+  - name: "get_user"
+    description: "Get user information by ID"
+    cluster: "user-service"
+    request:
+      method: "GET"
+      path: "/api/users/{id}"
+      timeout: "10s"
+    args:
+      - name: "id"
+        type: "integer"
+        in: "path"
+        description: "User ID"
+        required: true
+```
+
+Tool fields:
+
+| Field | Meaning |
+|---|---|
+| `name` | MCP tool name used by clients |
+| `description` | LLM-readable tool behavior |
+| `cluster` | Backend HTTP cluster to call |
+| `backend_url` | Optional dynamic-registry URL used by adapter flows |
+| `request.method` | `GET`, `POST`, `PUT`, `DELETE`, etc. |
+| `request.path` | Backend path, may include `{name}` placeholders |
+| `request.timeout` | Upstream timeout string |
+| `request.headers` | Present in the model, but current `buildBackendRequest` does not apply it at runtime |
+
+Current source note: `RequestConfig.Headers` exists in the model, but the
+MCP tool-call path does not copy those headers into the backend request
+yet. For POST/PUT tools with body args, Pixiu sets
+`Content-Type: application/json` automatically.
+
+Arg fields:
+
+| Field | Values |
+|---|---|
+| `type` | `string`, `integer`, `number`, `boolean` |
+| `in` | `path`, `query`, `body` |
+
+Path placeholders such as `/api/users/{id}` should have a matching arg
+with `name: id` and `in: path`.
+
+## Resources
+
+```yaml
+resources:
+  - name: "service-doc"
+    uri: "docs://service"
+    description: "Backend service documentation"
+    mime_type: "text/markdown"
+    source:
+      type: "inline"
+      content: "# Service Docs"
+```
+
+Supported source shapes in the model are `file`, `url`, `inline`, and
+`template`.
+
+## Resource Templates
+
+```yaml
+resource_templates:
+  - name: "user-doc"
+    uri_template: "docs://users/{id}"
+    title: "User docs"
+    description: "Documentation for a user"
+    mime_type: "text/plain"
+    parameters:
+      - name: "id"
+        type: "string"
+        required: true
+```
+
+## Prompts
+
+```yaml
+prompts:
+  - name: "summarize_user"
+    title: "Summarize user"
+    description: "Summarize user data"
+    arguments:
+      - name: "user_id"
+        required: true
+    messages:
+      - role: "user"
+        content: "Summarize user {{user_id}}"
+```
+
+Prompt message roles are `user` or `assistant`.

--- a/skills/pixiu-mcp-integration/references/mcp-transport.md
+++ b/skills/pixiu-mcp-integration/references/mcp-transport.md
@@ -1,0 +1,65 @@
+# MCP Transport Notes
+
+Current source anchors:
+
+- `pkg/filter/mcp/mcpserver/filter.go`
+- `pkg/filter/mcp/mcpserver/transport/`
+- `pkg/common/constant/http.go`
+
+Pixiu's MCP filter supports Streamable HTTP behavior:
+
+- `POST /mcp` carries JSON-RPC requests.
+- `GET /mcp` with `Accept: text/event-stream` establishes an SSE stream.
+- `Mcp-Session-Id` is returned/used for session continuity.
+- `Mcp-Protocol-Version` may be supplied by clients; server currently
+  responds with `2025-06-18`.
+
+## Initialize
+
+```sh
+curl -i -X POST http://localhost:8888/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","clientInfo":{"name":"curl","version":"1.0.0"}}}'
+```
+
+Expect JSON response and `Mcp-Session-Id`.
+
+## Initialized Notification
+
+```sh
+curl -i -X POST http://localhost:8888/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Mcp-Session-Id: <session-id>' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+```
+
+Expect `202 Accepted`.
+
+## List Tools
+
+```sh
+curl -s -X POST http://localhost:8888/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Mcp-Session-Id: <session-id>' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```
+
+## SSE Stream
+
+```sh
+curl -N http://localhost:8888/mcp \
+  -H 'Accept: text/event-stream' \
+  -H 'Mcp-Session-Id: <session-id>'
+```
+
+GET without `Accept: text/event-stream` should return 406.
+
+## stdio MCP Servers
+
+Pixiu does not spawn stdio MCP processes. To integrate a stdio server:
+
+1. Run an external bridge that exposes the stdio server over HTTP/SSE.
+2. Configure Pixiu MCP tools to call that bridge as a backend HTTP
+   service, or expose the bridge directly behind `httpproxy`.
+3. Document bridge lifecycle and health checks outside Pixiu.

--- a/skills/pixiu-mcp-integration/references/troubleshooting.md
+++ b/skills/pixiu-mcp-integration/references/troubleshooting.md
@@ -1,0 +1,40 @@
+# MCP Gateway Troubleshooting
+
+## 404 or route not matched
+
+- Check the route prefix/path covers the MCP endpoint.
+- Current MCP filter only handles requests where URL path exactly equals
+  `config.endpoint`, usually `/mcp`.
+
+## `tools/list` is empty
+
+- Static `tools` may be missing under the MCP filter config.
+- If using Nacos, check the adapter is configured and logs show dynamic
+  config applied.
+- Confirm `dgp.filter.mcp.mcpserver` appears before proxy filters.
+
+## `tools/call` does not reach backend
+
+- Every tool `cluster` must exist in `static_resources.clusters[]` or be
+  dynamically supplied by the adapter.
+- `dgp.filter.http.httpproxy` must appear after the MCP server filter.
+- Path placeholders like `{id}` should have matching `args` entries with
+  `in: path`.
+
+## SSE GET returns 406
+
+- Client must send `Accept: text/event-stream`.
+- Use `Mcp-Session-Id` from initialize if resuming a session.
+
+## Auth does not protect the endpoint
+
+- `dgp.filter.http.auth.mcp` must be before `dgp.filter.mcp.mcpserver`.
+- `rules[].cluster` must match the route cluster for the MCP endpoint.
+- `resource_metadata.resource` and provider `audience` must match the
+  token audience expected by the issuer.
+
+## stdio MCP server does not work
+
+Pixiu does not launch stdio MCP servers. Run a bridge outside Pixiu and
+expose it over HTTP/SSE, then configure Pixiu routes/tools to call that
+bridge.

--- a/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
+++ b/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
@@ -45,15 +45,26 @@ trap cleanup EXIT
 
 section() { echo; echo "== $* =="; }
 
+if ! has_yaml_reader; then
+  echo "error: install yq (preferred) or ruby for YAML parsing." >&2
+  echo "       macOS: brew install yq" >&2
+  echo "       Debian/Ubuntu: apt install yq" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "error: python3 is required for MCP semantic validation." >&2
+  echo "       macOS: brew install python" >&2
+  echo "       Debian/Ubuntu: apt install python3" >&2
+  exit 1
+fi
+
 section "1. YAML syntax"
 tmpjson=$(mktemp -t pixiu-mcp-XXXXXX.json)
 tmp_files+=("$tmpjson")
 yaml_err=$(mktemp -t pixiu-mcp-yaml-XXXXXX)
 tmp_files+=("$yaml_err")
-if ! has_yaml_reader; then
-  echo "  SKIP (install yq or ruby for YAML parsing)"
-  errors=$((errors+1))
-elif yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
+if yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
   echo "  OK"
 else
   echo "  FAIL:"; cat "$yaml_err"
@@ -61,13 +72,7 @@ else
 fi
 
 section "2. MCP gateway semantics"
-if ! has_yaml_reader; then
-  echo "  SKIP (install yq or ruby for YAML parsing; YAML syntax section already recorded this)"
-elif ! command -v python3 >/dev/null 2>&1; then
-  echo "  SKIP (install python3 for semantic validation)"
-  errors=$((errors+1))
-else
-  semantic_errors=$(python3 - "$tmpjson" <<'PY'
+semantic_errors=$(python3 - "$tmpjson" <<'PY'
 import json
 import re
 import sys
@@ -260,14 +265,13 @@ print("\n".join(errors))
 PY
 )
 
-  if [[ -n "$semantic_errors" ]]; then
-    echo "  FAIL:"
-    formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
-    printf '%s\n' "$formatted"
-    errors=$((errors+1))
-  else
-    echo "  OK"
-  fi
+if [[ -n "$semantic_errors" ]]; then
+  echo "  FAIL:"
+  formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
+  printf '%s\n' "$formatted"
+  errors=$((errors+1))
+else
+  echo "  OK"
 fi
 
 echo

--- a/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
+++ b/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# validate-mcp-config.sh — structural validation for pixiu MCP gateway conf.yaml.
+#
+# Usage:
+#   validate-mcp-config.sh <conf.yaml>
+#
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <conf.yaml>" >&2
+  exit 1
+fi
+
+CONF="$1"
+if [[ ! -f "$CONF" ]]; then
+  echo "error: $CONF not found" >&2
+  exit 1
+fi
+
+yaml_to_json() {
+  local file="$1"
+  if command -v yq >/dev/null 2>&1; then
+    yq -o json eval '.' "$file"
+  elif command -v ruby >/dev/null 2>&1; then
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+  else
+    return 127
+  fi
+}
+
+errors=0
+section() { echo; echo "== $* =="; }
+
+section "1. YAML syntax"
+tmpjson=$(mktemp -t pixiu-mcp-XXXXXX.json)
+if yaml_to_json "$CONF" > "$tmpjson" 2>/tmp/pixiu-mcp-yaml.err; then
+  echo "  OK"
+else
+  echo "  FAIL:"; cat /tmp/pixiu-mcp-yaml.err
+  rm -f "$tmpjson"
+  exit 2
+fi
+
+section "2. MCP gateway semantics"
+semantic_errors=$(python3 - "$tmpjson" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    cfg = json.load(f) or {}
+
+errors = []
+sr = cfg.get("static_resources") or cfg
+listeners = sr.get("listeners") or []
+clusters = sr.get("clusters") or cfg.get("clusters") or []
+cluster_names = {c.get("name") for c in clusters if isinstance(c, dict)}
+
+all_http_filters = []
+routes = []
+for listener in listeners:
+    for chain in (((listener or {}).get("filter_chains") or {}).get("filters") or []):
+        if not isinstance(chain, dict):
+            continue
+        if chain.get("name") != "dgp.filter.httpconnectionmanager":
+            continue
+        hcm = chain.get("config") or {}
+        routes.extend(((hcm.get("route_config") or {}).get("routes") or []))
+        all_http_filters.extend(hcm.get("http_filters") or [])
+
+filter_names = [f.get("name") for f in all_http_filters if isinstance(f, dict)]
+if "dgp.filter.mcp.mcpserver" not in filter_names:
+    errors.append("missing dgp.filter.mcp.mcpserver in http_filters")
+else:
+    mcp_i = filter_names.index("dgp.filter.mcp.mcpserver")
+    if "dgp.filter.http.auth.mcp" in filter_names and filter_names.index("dgp.filter.http.auth.mcp") > mcp_i:
+        errors.append("dgp.filter.http.auth.mcp must be before dgp.filter.mcp.mcpserver")
+    if "dgp.filter.http.httpproxy" in filter_names and filter_names.index("dgp.filter.http.httpproxy") < mcp_i:
+        errors.append("dgp.filter.http.httpproxy should be after dgp.filter.mcp.mcpserver")
+
+route_clusters = set()
+for route in routes:
+    cluster = ((route or {}).get("route") or {}).get("cluster")
+    if cluster:
+        route_clusters.add(cluster)
+        if cluster not in cluster_names:
+            errors.append(f"route references missing cluster {cluster!r}")
+
+valid_arg_types = {"string", "integer", "number", "boolean"}
+valid_arg_in = {"path", "query", "body"}
+for f in all_http_filters:
+    if not isinstance(f, dict) or f.get("name") != "dgp.filter.mcp.mcpserver":
+        continue
+    c = f.get("config") or {}
+    endpoint = c.get("endpoint", "/mcp")
+    if not str(endpoint).startswith("/"):
+        errors.append("mcp endpoint must start with /")
+    for tool in c.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name", "<unnamed>")
+        cluster = tool.get("cluster")
+        if not cluster:
+            errors.append(f"tool {name}: cluster is required")
+        elif cluster not in cluster_names:
+            errors.append(f"tool {name}: cluster {cluster!r} is not declared")
+        req = tool.get("request") or {}
+        path = req.get("path", "")
+        if not req.get("method"):
+            errors.append(f"tool {name}: request.method is required")
+        if not path:
+            errors.append(f"tool {name}: request.path is required")
+        args = tool.get("args") or []
+        arg_by_name = {a.get("name"): a for a in args if isinstance(a, dict)}
+        for placeholder in re.findall(r"\{([^}]+)\}", str(path)):
+            arg = arg_by_name.get(placeholder)
+            if not arg or arg.get("in") != "path":
+                errors.append(f"tool {name}: path placeholder {{{placeholder}}} needs matching arg with in: path")
+        for arg in args:
+            if not isinstance(arg, dict):
+                continue
+            if arg.get("type", "string") not in valid_arg_types:
+                errors.append(f"tool {name}: arg {arg.get('name')} has invalid type {arg.get('type')!r}")
+            if arg.get("in") not in valid_arg_in:
+                errors.append(f"tool {name}: arg {arg.get('name')} has invalid in {arg.get('in')!r}")
+
+for f in all_http_filters:
+    if not isinstance(f, dict) or f.get("name") != "dgp.filter.http.auth.mcp":
+        continue
+    c = f.get("config") or {}
+    rm = c.get("resource_metadata") or {}
+    if not rm.get("resource"):
+        errors.append("mcp auth resource_metadata.resource is required")
+    if not rm.get("authorization_servers"):
+        errors.append("mcp auth resource_metadata.authorization_servers is required")
+    providers = c.get("providers") or []
+    if not providers:
+        errors.append("mcp auth providers must not be empty")
+    for p in providers:
+        if not isinstance(p, dict):
+            continue
+        for key in ("name", "issuer", "jwks"):
+            if not p.get(key):
+                errors.append(f"mcp auth provider missing {key}")
+    for rule in c.get("rules") or []:
+        cluster = (rule or {}).get("cluster")
+        if not cluster:
+            errors.append("mcp auth rule cluster is required")
+        elif cluster not in route_clusters:
+            errors.append(f"mcp auth rule cluster {cluster!r} does not match any route cluster")
+
+adapters = cfg.get("adapters") or sr.get("adapters") or []
+for adapter in adapters:
+    if not isinstance(adapter, dict) or adapter.get("name") != "dgp.adapter.mcpserver":
+        continue
+    regs = ((adapter.get("config") or {}).get("registries") or {})
+    if not regs:
+        errors.append("mcpserver adapter has no registries")
+    for name, reg in regs.items():
+        if (reg or {}).get("protocol") != "nacos":
+            errors.append(f"mcp registry {name} protocol should be nacos for current source")
+        if not (reg or {}).get("address"):
+            errors.append(f"mcp registry {name} address is empty")
+
+print("\n".join(errors))
+PY
+)
+rm -f "$tmpjson"
+
+if [[ -n "$semantic_errors" ]]; then
+  echo "  FAIL:"
+  echo "$semantic_errors" | sed 's/^/    - /'
+  errors=$((errors+1))
+else
+  echo "  OK"
+fi
+
+echo
+if [[ $errors -eq 0 ]]; then
+  echo "Validation passed."
+  exit 0
+else
+  echo "Validation failed with $errors error group(s)."
+  exit 2
+fi

--- a/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
+++ b/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
@@ -23,27 +23,51 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV.fetch(0)))' "$file"
+    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
   else
     return 127
   fi
 }
 
+has_yaml_reader() {
+  command -v yq >/dev/null 2>&1 || command -v ruby >/dev/null 2>&1
+}
+
 errors=0
+tmp_files=()
+
+cleanup() {
+  if [[ ${#tmp_files[@]} -gt 0 ]]; then
+    rm -f "${tmp_files[@]}"
+  fi
+}
+trap cleanup EXIT
+
 section() { echo; echo "== $* =="; }
 
 section "1. YAML syntax"
 tmpjson=$(mktemp -t pixiu-mcp-XXXXXX.json)
-if yaml_to_json "$CONF" > "$tmpjson" 2>/tmp/pixiu-mcp-yaml.err; then
+tmp_files+=("$tmpjson")
+yaml_err=$(mktemp -t pixiu-mcp-yaml-XXXXXX)
+tmp_files+=("$yaml_err")
+if ! has_yaml_reader; then
+  echo "  SKIP (install yq or ruby for YAML parsing)"
+  errors=$((errors+1))
+elif yaml_to_json "$CONF" > "$tmpjson" 2>"$yaml_err"; then
   echo "  OK"
 else
-  echo "  FAIL:"; cat /tmp/pixiu-mcp-yaml.err
-  rm -f "$tmpjson"
+  echo "  FAIL:"; cat "$yaml_err"
   exit 2
 fi
 
 section "2. MCP gateway semantics"
-semantic_errors=$(python3 - "$tmpjson" <<'PY'
+if ! has_yaml_reader; then
+  echo "  SKIP (install yq or ruby for YAML parsing; YAML syntax section already recorded this)"
+elif ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP (install python3 for semantic validation)"
+  errors=$((errors+1))
+else
+  semantic_errors=$(python3 - "$tmpjson" <<'PY'
 import json
 import re
 import sys
@@ -59,8 +83,24 @@ cluster_names = {c.get("name") for c in clusters if isinstance(c, dict)}
 
 all_http_filters = []
 routes = []
+
+def network_filters(listener):
+    if not isinstance(listener, dict):
+        return []
+    filter_chains = listener.get("filter_chains") or []
+    if isinstance(filter_chains, dict):
+        filter_chains = [filter_chains]
+    elif not isinstance(filter_chains, list):
+        return []
+
+    filters = []
+    for fc in filter_chains:
+        if isinstance(fc, dict):
+            filters.extend(fc.get("filters") or [])
+    return filters
+
 for listener in listeners:
-    for chain in (((listener or {}).get("filter_chains") or {}).get("filters") or []):
+    for chain in network_filters(listener):
         if not isinstance(chain, dict):
             continue
         if chain.get("name") != "dgp.filter.httpconnectionmanager":
@@ -166,14 +206,15 @@ for adapter in adapters:
 print("\n".join(errors))
 PY
 )
-rm -f "$tmpjson"
 
-if [[ -n "$semantic_errors" ]]; then
-  echo "  FAIL:"
-  echo "$semantic_errors" | sed 's/^/    - /'
-  errors=$((errors+1))
-else
-  echo "  OK"
+  if [[ -n "$semantic_errors" ]]; then
+    echo "  FAIL:"
+    formatted="    - ${semantic_errors//$'\n'/$'\n    - '}"
+    printf '%s\n' "$formatted"
+    errors=$((errors+1))
+  else
+    echo "  OK"
+  fi
 fi
 
 echo

--- a/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
+++ b/skills/pixiu-mcp-integration/scripts/validate-mcp-config.sh
@@ -23,7 +23,7 @@ yaml_to_json() {
   if command -v yq >/dev/null 2>&1; then
     yq -o json eval '.' "$file"
   elif command -v ruby >/dev/null 2>&1; then
-    ruby -ryaml -rjson -e 'puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false))' "$file"
+    ruby -ryaml -rjson -e 'begin; puts JSON.generate(YAML.safe_load(File.read(ARGV.fetch(0)), permitted_classes: [], permitted_symbols: [], aliases: false)); rescue StandardError => e; warn "#{e.class}: #{e.message}"; exit 1; end' "$file"
   else
     return 127
   fi
@@ -73,13 +73,52 @@ import re
 import sys
 
 with open(sys.argv[1], "r", encoding="utf-8") as f:
-    cfg = json.load(f) or {}
+    raw_cfg = json.load(f)
 
 errors = []
-sr = cfg.get("static_resources") or cfg
-listeners = sr.get("listeners") or []
-clusters = sr.get("clusters") or cfg.get("clusters") or []
-cluster_names = {c.get("name") for c in clusters if isinstance(c, dict)}
+
+def dict_field(container, key, label):
+    if not isinstance(container, dict):
+        return {}
+    value = container.get(key)
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{label} must be a map/object")
+    return {}
+
+def list_field(container, key, label):
+    if not isinstance(container, dict):
+        return []
+    value = container.get(key)
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    errors.append(f"{label} must be a list")
+    return []
+
+if not isinstance(raw_cfg, dict):
+    errors.append("top-level config must be a map/object")
+    cfg = {}
+else:
+    cfg = raw_cfg
+
+sr_value = cfg.get("static_resources")
+if sr_value is None:
+    sr = cfg
+elif isinstance(sr_value, dict):
+    sr = sr_value
+else:
+    errors.append("static_resources must be a map/object")
+    sr = {}
+
+listeners = list_field(sr, "listeners", "static_resources.listeners")
+clusters = list_field(sr, "clusters", "static_resources.clusters")
+if not clusters and sr is not cfg:
+    clusters = list_field(cfg, "clusters", "clusters")
+cluster_names = {c.get("name") for c in clusters if isinstance(c, dict) and c.get("name")}
 
 all_http_filters = []
 routes = []
@@ -105,9 +144,9 @@ for listener in listeners:
             continue
         if chain.get("name") != "dgp.filter.httpconnectionmanager":
             continue
-        hcm = chain.get("config") or {}
-        routes.extend(((hcm.get("route_config") or {}).get("routes") or []))
-        all_http_filters.extend(hcm.get("http_filters") or [])
+        hcm = dict_field(chain, "config", "dgp.filter.httpconnectionmanager.config")
+        routes.extend(list_field(dict_field(hcm, "route_config", "route_config"), "routes", "route_config.routes"))
+        all_http_filters.extend(list_field(hcm, "http_filters", "http_filters"))
 
 filter_names = [f.get("name") for f in all_http_filters if isinstance(f, dict)]
 if "dgp.filter.mcp.mcpserver" not in filter_names:
@@ -121,7 +160,7 @@ else:
 
 route_clusters = set()
 for route in routes:
-    cluster = ((route or {}).get("route") or {}).get("cluster")
+    cluster = dict_field(route, "route", "route.route").get("cluster")
     if cluster:
         route_clusters.add(cluster)
         if cluster not in cluster_names:
@@ -132,11 +171,11 @@ valid_arg_in = {"path", "query", "body"}
 for f in all_http_filters:
     if not isinstance(f, dict) or f.get("name") != "dgp.filter.mcp.mcpserver":
         continue
-    c = f.get("config") or {}
+    c = dict_field(f, "config", "dgp.filter.mcp.mcpserver.config")
     endpoint = c.get("endpoint", "/mcp")
     if not str(endpoint).startswith("/"):
         errors.append("mcp endpoint must start with /")
-    for tool in c.get("tools") or []:
+    for tool in list_field(c, "tools", "mcpserver tools"):
         if not isinstance(tool, dict):
             continue
         name = tool.get("name", "<unnamed>")
@@ -145,13 +184,13 @@ for f in all_http_filters:
             errors.append(f"tool {name}: cluster is required")
         elif cluster not in cluster_names:
             errors.append(f"tool {name}: cluster {cluster!r} is not declared")
-        req = tool.get("request") or {}
+        req = dict_field(tool, "request", f"tool {name}.request")
         path = req.get("path", "")
         if not req.get("method"):
             errors.append(f"tool {name}: request.method is required")
         if not path:
             errors.append(f"tool {name}: request.path is required")
-        args = tool.get("args") or []
+        args = list_field(tool, "args", f"tool {name}.args")
         arg_by_name = {a.get("name"): a for a in args if isinstance(a, dict)}
         for placeholder in re.findall(r"\{([^}]+)\}", str(path)):
             arg = arg_by_name.get(placeholder)
@@ -168,13 +207,13 @@ for f in all_http_filters:
 for f in all_http_filters:
     if not isinstance(f, dict) or f.get("name") != "dgp.filter.http.auth.mcp":
         continue
-    c = f.get("config") or {}
-    rm = c.get("resource_metadata") or {}
+    c = dict_field(f, "config", "dgp.filter.http.auth.mcp.config")
+    rm = dict_field(c, "resource_metadata", "mcp auth resource_metadata")
     if not rm.get("resource"):
         errors.append("mcp auth resource_metadata.resource is required")
     if not rm.get("authorization_servers"):
         errors.append("mcp auth resource_metadata.authorization_servers is required")
-    providers = c.get("providers") or []
+    providers = list_field(c, "providers", "mcp auth providers")
     if not providers:
         errors.append("mcp auth providers must not be empty")
     for p in providers:
@@ -183,24 +222,38 @@ for f in all_http_filters:
         for key in ("name", "issuer", "jwks"):
             if not p.get(key):
                 errors.append(f"mcp auth provider missing {key}")
-    for rule in c.get("rules") or []:
-        cluster = (rule or {}).get("cluster")
+    for rule in list_field(c, "rules", "mcp auth rules"):
+        rule = dict_field({"rule": rule}, "rule", "mcp auth rule")
+        cluster = rule.get("cluster")
         if not cluster:
             errors.append("mcp auth rule cluster is required")
         elif cluster not in route_clusters:
             errors.append(f"mcp auth rule cluster {cluster!r} does not match any route cluster")
 
-adapters = cfg.get("adapters") or sr.get("adapters") or []
+if cfg.get("adapters") is not None:
+    adapters = list_field(cfg, "adapters", "adapters")
+else:
+    adapters = list_field(sr, "adapters", "static_resources.adapters")
 for adapter in adapters:
     if not isinstance(adapter, dict) or adapter.get("name") != "dgp.adapter.mcpserver":
         continue
-    regs = ((adapter.get("config") or {}).get("registries") or {})
-    if not regs:
+    adapter_config = dict_field(adapter, "config", "mcpserver adapter config")
+    regs_value = adapter_config.get("registries")
+    if regs_value is None:
         errors.append("mcpserver adapter has no registries")
-    for name, reg in regs.items():
-        if (reg or {}).get("protocol") != "nacos":
+        continue
+    if not isinstance(regs_value, dict):
+        errors.append("mcpserver adapter registries must be a map/object")
+        continue
+    if not regs_value:
+        errors.append("mcpserver adapter has no registries")
+    for name, reg in regs_value.items():
+        if not isinstance(reg, dict):
+            errors.append(f"mcp registry {name} must be a map/object")
+            continue
+        if reg.get("protocol") != "nacos":
             errors.append(f"mcp registry {name} protocol should be nacos for current source")
-        if not (reg or {}).get("address"):
+        if not reg.get("address"):
             errors.append(f"mcp registry {name} address is empty")
 
 print("\n".join(errors))


### PR DESCRIPTION
**What this PR does**:

Adds four Pixiu skills for working with Apache dubbo-go-pixiu:

- `pixiu-filter-author`: guides HTTP / Network filter authoring, SPI registration, config wiring, and test decisions.
- `pixiu-http-to-dubbo`: guides REST/HTTP to Dubbo route configuration through `conf.yaml` and `api_config.yaml`.
- `pixiu-llm-gateway`: guides Pixiu LLM gateway configuration, including LLM proxy, tokenizer metrics, KV cache routing, retry/fallback, and Nacos LLM discovery.
- `pixiu-mcp-integration`: guides MCP gateway configuration, including Streamable HTTP/SSE, tools, OAuth/JWT protection, and Nacos MCP tool discovery.

Each skill includes focused reference documents for schema details, troubleshooting, validation rules, and common pitfalls.

**Which issue(s) this PR fixes**:

Fixes #913

**Special notes for your reviewer**:

This PR only adds skill documentation and references. It does not change dubbo-go-pixiu runtime code.

The skills are written to match current Pixiu configuration and extension patterns, including:

- current filter Kind names
- HTTP filter registration via `pkg/pluginregistry/registry.go`
- current `api_config.yaml` mapping rules
- current LLM `llm_meta` and Nacos metadata conventions
- current MCP filter/auth behavior and known limitations

**Does this PR introduce a user-facing change?**:

```release-note
Added four Pixiu skills for filter authoring, HTTP-to-Dubbo configuration, LLM gateway setup, and MCP gateway integration.
```

## Summary by Sourcery

Add Pixiu-focused skills, reference docs, and validation/scaffolding scripts to guide configuration of HTTP-to-Dubbo routes, filter authoring, LLM gateway setup, and MCP gateway integration without changing runtime behavior.

Enhancements:
- Add shell scripts to scaffold new HTTP filters, validate api_config.yaml, and validate LLM and MCP gateway conf.yaml files, improving configuration correctness and developer workflows.

Documentation:
- Document the pixiu-http-to-dubbo skill for configuring HTTP routes to Dubbo backends via conf.yaml and api_config.yaml, including mapping rules, validation workflow, and troubleshooting guidance.
- Document the pixiu-filter-author skill for authoring and registering HTTP and network filters in dubbo-go-pixiu, with guidance on SPI usage, config wiring, and testing conventions.
- Document the pixiu-llm-gateway skill for configuring Pixiu as an LLM gateway, covering LLM proxy, tokenizer, KV cache routing, and Nacos-based LLM discovery from conf.yaml.
- Document the pixiu-mcp-integration skill for configuring Pixiu as an MCP gateway, including tools/resources/prompts, auth, Nacos-based tool discovery, and transport expectations.
- Add detailed reference documents for filter interfaces, context API, plugin registry usage, testing patterns, api_config schema and mapping rules, generic invoke types, and troubleshooting for HTTP-to-Dubbo, LLM, and MCP gateways.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive filter-authoring guides (interfaces, context API, lifecycle, testing, registration, templates, and verification checklists).
  * Added HTTP→Dubbo mapping docs with schema, param-mapping, generic-invoke guidance, validation, and troubleshooting.
  * Added LLM gateway guides (kvcache, endpoints, registry, tokenizer metrics, troubleshooting).
  * Added MCP integration docs (auth, transport, server config, registry, and troubleshooting).

* **Chores**
  * Added scaffolding, registry-import generator, and multiple validation scripts for filter, API-config, LLM, and MCP configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->