### PR TITLE
fix(accesslog): avoid max latency after decode short-circuit

### DIFF
--- a/pkg/filter/accesslog/access_log.go
+++ b/pkg/filter/accesslog/access_log.go
@@ -79,8 +79,9 @@ func (factory *FilterFactory) PrepareFilterChain(ctx *http.HttpContext, chain fi
 	// Make a shallow copy of the factory config to avoid sharing the factory's pointer.
 	cpConf := *factory.conf
 	f := &Filter{
-		conf: &cpConf,
-		alw:  factory.alw,
+		conf:  &cpConf,
+		alw:   factory.alw,
+		start: time.Now(),
 	}
 	chain.AppendDecodeFilters(f)
 	chain.AppendEncodeFilters(f)

--- a/pkg/filter/accesslog/access_log_test.go
+++ b/pkg/filter/accesslog/access_log_test.go
@@ -108,7 +108,15 @@ func TestEncodeWithoutDecodeReportsBoundedLatency(t *testing.T) {
 	chain.OnDecode(ctx)
 	chain.OnEncode(ctx)
 
-	entry := <-logData
+	var entry AccessLogData
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case entry = <-logData:
+	case <-timer.C:
+		t.Fatal("timed out waiting for access-log entry")
+	}
+
 	matches := accessLogCostPattern.FindStringSubmatch(entry.AccessLogMsg)
 	if assert.Len(t, matches, 2) {
 		latency, parseErr := strconv.ParseInt(matches[1], 10, 64)

--- a/pkg/filter/accesslog/access_log_test.go
+++ b/pkg/filter/accesslog/access_log_test.go
@@ -21,6 +21,8 @@ import (
 	"bytes"
 	"net/http"
 	"os"
+	"regexp"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -32,9 +34,19 @@ import (
 import (
 	"github.com/apache/dubbo-go-pixiu/pkg/client"
 	"github.com/apache/dubbo-go-pixiu/pkg/common/constant"
+	filterapi "github.com/apache/dubbo-go-pixiu/pkg/common/extension/filter"
+	contexthttp "github.com/apache/dubbo-go-pixiu/pkg/context/http"
 	"github.com/apache/dubbo-go-pixiu/pkg/context/mock"
 	"github.com/apache/dubbo-go-pixiu/pkg/logger"
 )
+
+var accessLogCostPattern = regexp.MustCompile(`cost time \[ ([0-9]+) \]`)
+
+type stoppingDecodeFilter struct{}
+
+func (stoppingDecodeFilter) Decode(*contexthttp.HttpContext) filterapi.FilterStatus {
+	return filterapi.Stop
+}
 
 func TestAccessLog_Write_to_file(t *testing.T) {
 	msg := "this is test msg"
@@ -76,4 +88,32 @@ func TestApply(t *testing.T) {
 		}
 	}
 	assert.FileExists(t, filePath, nil)
+}
+
+func TestEncodeWithoutDecodeReportsBoundedLatency(t *testing.T) {
+	logData := make(chan AccessLogData, 1)
+	factory := &FilterFactory{
+		conf: &AccessLogConfig{},
+		alw:  &AccessLogWriter{AccessLogDataChan: logData},
+	}
+	chain := filterapi.NewDefaultFilterChain()
+	chain.AppendDecodeFilters(stoppingDecodeFilter{})
+
+	request, err := http.NewRequest(http.MethodGet, "http://www.dubbogopixiu.com/blocked", nil)
+	assert.NoError(t, err)
+	ctx := mock.GetMockHTTPContext(request)
+	ctx.TargetResp = client.NewUnaryResponse([]byte("blocked"))
+
+	assert.NoError(t, factory.PrepareFilterChain(ctx, chain))
+	chain.OnDecode(ctx)
+	chain.OnEncode(ctx)
+
+	entry := <-logData
+	matches := accessLogCostPattern.FindStringSubmatch(entry.AccessLogMsg)
+	if assert.Len(t, matches, 2) {
+		latency, parseErr := strconv.ParseInt(matches[1], 10, 64)
+		if assert.NoError(t, parseErr) {
+			assert.Less(t, time.Duration(latency), time.Minute)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does**:

The access-log filter records its start timestamp in `Decode`. When an earlier
decode filter returns `filter.Stop`, access-log decode is skipped, but the HTTP
connection manager still runs the complete reverse encode chain. The access-log
encode path then computes `time.Since` from Go's zero `time.Time`, which
saturates at `time.Duration(math.MaxInt64)` and logs
`9223372036854775807` nanoseconds.

This change:

- initializes a per-request fallback start timestamp when the access-log filter
  is added to the chain;
- keeps the existing `Decode` assignment so normally decoded requests retain
  the current timing boundary;
- adds a regression test using the real filter chain, with an earlier filter
  stopping decode before access logging.

There are no filter-chain API or access-log format changes.

**Which issue(s) this PR fixes**:

Fixes https://github.com/apache/dubbo-go-pixiu/issues/1015

The same MaxInt64 value is visible in the error-path log attached to
https://github.com/apache/dubbo-go-pixiu/issues/724.

**Special notes for your reviewer**:

The fallback timestamp is created per request in `PrepareFilterChain`; it is not
shared by the factory. `Decode` still refreshes the timestamp when access-log
decode is reached, so the normal request path is unchanged.

Before the production change, the new regression test failed with:

```text
"2562047h47m16.854775807s" is not less than "1m0s"
```

Validation on the fixed implementation:

```text
go test ./pkg/filter/accesslog -run TestEncodeWithoutDecodeReportsBoundedLatency -count=1
go test ./pkg/filter/accesslog -count=1
go test -race ./pkg/filter/accesslog ./pkg/common/extension/filter ./pkg/common/http -count=1
go vet ./pkg/filter/accesslog ./pkg/common/extension/filter ./pkg/common/http
golangci-lint run ./pkg/filter/accesslog
go test ./...
git diff --check
```

All commands pass on `develop` at `60fcbf17` with this change.

**Does this PR introduce a user-facing change?**:

```release-note
Access logs no longer report MaxInt64 latency when HTTP decode is short-circuited by an earlier filter.
```

## Summary by Sourcery

Ensure access log latency is bounded when HTTP decode is short-circuited by an earlier filter.

Bug Fixes:
- Prevent access logs from recording MaxInt64 latency when the access-log decode phase is skipped due to an earlier filter stopping decode.

Tests:
- Add an integration-style test that builds a real filter chain with a short-circuiting decode filter to verify encode-only access logging reports bounded latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Access logs now consistently include a valid, bounded latency value, including when request processing stops early.

* **Tests**
  * Added coverage to verify access-log entries are emitted correctly after decode termination and contain parseable latency information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->